### PR TITLE
fix: assistEquip 默认值从数组改为字符串，修复 BBC UI 初始化失败

### DIFF
--- a/agent/chaldea/bbc_formatter.py
+++ b/agent/chaldea/bbc_formatter.py
@@ -106,7 +106,7 @@ def _determine_assist_info(formation: TeamFormation) -> Tuple[int, str, Union[st
     """确定助战相关信息，返回 (assist_idx, assist_mode, assist_equip, used_servant)"""
     assist_idx = None
     assist_mode = "从者礼装"
-    assist_equip: Union[str, List[Optional[str]]] = [None, None, None]
+    assist_equip: Union[str, List[Optional[str]]] = "迦勒底午茶时光"
     used_servant: List[int] = []
 
     for i, svt in enumerate(formation.on_field):


### PR DESCRIPTION
当 assistMode 为'从者礼装'时，BBC 期望 assistEquip 是字符串类型，
但转换器默认输出 [None, None, None] 数组导致类型不匹配。
将默认值改为'迦勒底午茶时光'（BBC 默认礼装名），与 BBC 行为一致。