### PR TITLE
Change packaging from 7z to zip for server compatibility and separate MFAA and MXU mirrorchyan_rid

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -163,13 +163,14 @@ jobs:
 
       - name: Compress Final Artifact
         run: |
-          7z a -t7z -mx=9 -mmt -ms -r ${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MWU.7z "./build/*"
+          cd build
+          zip -r "../${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MWU.zip" .
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MWU
-          path: ${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MWU.7z
+          path: ${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MWU.zip
 
   build-mxu:
     env:
@@ -277,13 +278,14 @@ jobs:
 
       - name: Compress MXU Artifact
         run: |
-          7z a -t7z -mx=9 -mmt -ms -r ${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MXU.7z "./install-mxu/*"
+          cd install-mxu
+          zip -r "../${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MXU.zip" .
 
       - name: Upload MXU Artifacts
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MXU
-          path: ${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MXU.7z
+          path: ${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MXU.zip
 
   build-avalonia:
     needs: meta
@@ -378,12 +380,13 @@ jobs:
       - name: Compress Avalonia artifact
         shell: bash
         run: |
-          7z a -t7z -mx=9 -mmt -ms -r -- ./${{ env.repo_name }}-${{ matrix.os }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.version }}-MFAA.7z ./install/*
+          cd install
+          zip -r "../${{ env.repo_name }}-${{ matrix.os }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.version }}-MFAA.zip" .
 
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ env.repo_name }}-${{ matrix.os }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.version }}-MFAA
-          path: ${{ env.repo_name }}-${{ matrix.os }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.version }}-MFAA.7z
+          path: ${{ env.repo_name }}-${{ matrix.os }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.version }}-MFAA.zip
 
   changelog:
     name: Generate changelog
@@ -434,7 +437,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2.2.2
         with:
-          files: release/**/*.7z
+          files: release/**/*.zip
           tag_name: ${{ needs.meta.outputs.tag }}
           body: ${{ needs.changelog.outputs.release_body }}
           draft: false

--- a/tools/install-Avalonia.py
+++ b/tools/install-Avalonia.py
@@ -154,6 +154,7 @@ def install_resource():
         interface = json.load(f)
 
     interface["version"] = version
+    interface["mirrorchyan_rid"] = "MaaFgo-MFAA"
 
     # 设置 agent 使用内置 Python
     if os_name == "win":

--- a/tools/install-MXU.py
+++ b/tools/install-MXU.py
@@ -117,7 +117,7 @@ def install_resource():
         interface = json.load(f)
 
     interface["version"] = version
-    interface["mirrorchyan_rid"] = "MaaFgo"
+    interface["mirrorchyan_rid"] = "MaaFgo-MXU"
 
     with open(install_path / "interface.json", "w", encoding="utf-8") as f:
         json.dump(interface, f, ensure_ascii=False, indent=4)

--- a/tools/install.py
+++ b/tools/install.py
@@ -116,6 +116,7 @@ def install_resource():
         interface = jsonc.load(f)
 
     interface["version"] = version
+    interface["mirrorchyan_rid"] = "MaaFgo-MFAA"
 
     with open(install_path / "interface.json", "w", encoding="utf-8") as f:
         jsonc.dump(interface, f, ensure_ascii=False, indent=4)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched build artifact format from 7z to zip across all platform releases
  * Updated internal installation configuration metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->