### PR TITLE
fix: 修复BBC回调端口占用导致重启失败

### DIFF
--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -11,7 +11,7 @@ _custom_dir = os.path.dirname(os.path.abspath(__file__))
 if _custom_dir not in sys.path:
     sys.path.insert(0, _custom_dir)
 
-from bbc_connection_manager import bbc_manager
+from bbc_connection_manager import get_manager
 import mfaalog
 
 
@@ -118,6 +118,9 @@ class ExecuteBbcTask(CustomAction):
             listener_thread.start()
             mfaalog.info("[ExecuteBbcTask] 弹窗监听线程已启动")
             
+            # 获取或创建 Manager 实例（进程级单例）
+            manager = get_manager()
+            
             # 步顤1: 尝试TCP连接，失败则触发bbc_start
             if not self._ensure_bbc_connected(context):
                 return {'success': False, 'error': 'BBC连接失败'}
@@ -132,15 +135,15 @@ class ExecuteBbcTask(CustomAction):
                     self._handle_popups([msg], support_order_mismatch, team_config_error, state)
                     state['popup_event'].set()  # 通知监听线程
             
-            bbc_manager.set_popup_callback(on_popup)
+            manager.set_popup_callback(on_popup)
             mfaalog.info("[ExecuteBbcTask] 弹窗回调已设置")
             
             # 清空消息队列，避免读取历史弹窗
-            bbc_manager.clear_message_queue()
+            manager.clear_message_queue()
             
             # 步顤2: 验证模拟器连接
             if not self._verify_emulator_connection(attach_data, context):
-                bbc_manager.disconnect_tcp()
+                manager.disconnect_tcp()
                 return {'success': False, 'error': '模拟器连接失败'}
             
             # 步骤3: 配置并启动战斗（同时启动回调监听）
@@ -149,13 +152,13 @@ class ExecuteBbcTask(CustomAction):
                 support_order_mismatch, team_config_error, state
             )
             if battle_result is None:
-                bbc_manager.disconnect_tcp()
+                manager.disconnect_tcp()
                 return {'success': False, 'error': '战斗启动失败'}
             
             # 步骤4: 等待战斗结束
             popup_title, popup_message = self._wait_for_battle_end(state)
             
-            bbc_manager.disconnect_tcp()
+            manager.disconnect_tcp()
             
             # 步骤5: 输出结果
             if popup_title or popup_message:
@@ -192,9 +195,10 @@ class ExecuteBbcTask(CustomAction):
     
     def _restart_bbc(self, context: Context) -> bool:
         """重启BBC进程"""
+        manager = get_manager()
         try:
             # 先断开当前连接
-            bbc_manager.disconnect_tcp()
+            manager.disconnect_tcp()
             time.sleep(1)
             
             mfaalog.info("[Restart] 停止BBC进程...")
@@ -222,8 +226,9 @@ class ExecuteBbcTask(CustomAction):
     
     def _ensure_bbc_connected(self, context: Context):
         """确保BBC已连接，必要时触发bbc_start"""
+        manager = get_manager()
         # 检查连接是否有效
-        if bbc_manager.ensure_connected(timeout=3):
+        if manager.ensure_connected(timeout=3):
             mfaalog.info("[ExecuteBbcTask] TCP连接有效")
             return True
         
@@ -237,7 +242,7 @@ class ExecuteBbcTask(CustomAction):
         
         # 重新检查连接
         time.sleep(2)
-        if bbc_manager.ensure_connected(timeout=5):
+        if manager.ensure_connected(timeout=5):
             mfaalog.info("[ExecuteBbcTask] bbc_start后TCP连接成功")
             return True
         
@@ -246,7 +251,8 @@ class ExecuteBbcTask(CustomAction):
     
     def _verify_emulator_connection(self, attach_data: dict, context: Context) -> bool:
         """验证模拟器连接，必要时调用Manager重启"""
-        conn_status = bbc_manager.send_command('get_connection', {}, timeout=5)
+        manager = get_manager()
+        conn_status = manager.send_command('get_connection', {}, timeout=5)
         
         # 检查是否有模拟器参数
         device_info = conn_status.get('device_info', {})
@@ -284,7 +290,7 @@ class ExecuteBbcTask(CustomAction):
                 }
             
             # 检查参数是否匹配
-            params_match = bbc_manager.check_emulator_params_match(connect_cmd, expected_args, emulator_params)
+            params_match = manager.check_emulator_params_match(connect_cmd, expected_args, emulator_params)
             if params_match:
                 mfaalog.info(f"[ExecuteBbcTask] 模拟器已连接且参数匹配: {emulator_params}")
                 return True
@@ -328,7 +334,7 @@ class ExecuteBbcTask(CustomAction):
             }
         
         # 调用Manager的完整重启流程
-        success = bbc_manager.restart_bbc_and_connect(connect_cmd, connect_args, max_retries=3)
+        success = manager.restart_bbc_and_connect(connect_cmd, connect_args, max_retries=3)
         
         if success:
             mfaalog.info("[ExecuteBbcTask] BBC重启并连接成功")
@@ -342,37 +348,38 @@ class ExecuteBbcTask(CustomAction):
                                 support_order_mismatch: bool, team_config_error: bool,
                                 state: dict) -> dict:
         """配置战斗参数并启动，返回 state 或 None"""
+        manager = get_manager()
         
         # 回调已在 _execute_single_battle 中设置，这里直接使用
         
         # 加载配置
         mfaalog.info(f"[ExecuteBbcTask] 加载配置: {team_config}")
-        result = bbc_manager.send_command('load_config', {'filename': team_config}, timeout=10)
+        result = manager.send_command('load_config', {'filename': team_config}, timeout=10)
         if not result.get('success'):
             mfaalog.error(f"[ExecuteBbcTask] 加载配置失败: {result.get('error')}")
             return None
         
         # 检查配置阶段是否有弹窗
-        popup_msgs = bbc_manager.get_messages_by_title('', timeout=1)
+        popup_msgs = manager.get_messages_by_title('', timeout=1)
         if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state):
             return state
         
         # 设置参数
         mfaalog.info(f"[ExecuteBbcTask] 设置苹果类型: {apple_type}")
-        bbc_manager.send_command('set_apple_type', {'apple_type': apple_type}, timeout=5)
+        manager.send_command('set_apple_type', {'apple_type': apple_type}, timeout=5)
         
-        popup_msgs = bbc_manager.get_messages_by_title('', timeout=1)
+        popup_msgs = manager.get_messages_by_title('', timeout=1)
         if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state):
             return state
         
         mfaalog.info(f"[ExecuteBbcTask] 设置运行次数: {run_count}")
-        bbc_manager.send_command('set_run_times', {'times': run_count}, timeout=5)
+        manager.send_command('set_run_times', {'times': run_count}, timeout=5)
         
         mfaalog.info(f"[ExecuteBbcTask] 设置战斗类型: {battle_type}")
-        bbc_manager.send_command('set_battle_type', {'battle_type': battle_type}, timeout=5)
+        manager.send_command('set_battle_type', {'battle_type': battle_type}, timeout=5)
         
         # 启动战斗前最后检查一次弹窗
-        popup_msgs = bbc_manager.get_messages_by_title('', timeout=1)
+        popup_msgs = manager.get_messages_by_title('', timeout=1)
         if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state):
             return state
         
@@ -383,7 +390,7 @@ class ExecuteBbcTask(CustomAction):
         
         for retry in range(max_retries):
             # 发送启动命令
-            result = bbc_manager.send_command('start_battle', {}, timeout=10)
+            result = manager.send_command('start_battle', {}, timeout=10)
             if not result.get('success'):
                 error = result.get('error', '')
                 mfaalog.error(f"[ExecuteBbcTask] 启动战斗命令失败: {error}")
@@ -398,7 +405,7 @@ class ExecuteBbcTask(CustomAction):
             
             # 等待并检查状态
             time.sleep(2)
-            ui_status = bbc_manager.send_command('get_ui_status', {}, timeout=5)
+            ui_status = manager.send_command('get_ui_status', {}, timeout=5)
             
             # 检查是否成功启动
             if ui_status.get('battle_running') or ui_status.get('device_running'):
@@ -416,7 +423,7 @@ class ExecuteBbcTask(CustomAction):
                 continue
             
             # 检查是否有其他弹窗
-            popup_msgs = bbc_manager.get_messages_by_title('', timeout=2)
+            popup_msgs = manager.get_messages_by_title('', timeout=2)
             if popup_msgs:
                 mfaalog.info(f"[ExecuteBbcTask] 检测到弹窗: {popup_msgs[0].get('popup_title', '')}")
         
@@ -431,6 +438,7 @@ class ExecuteBbcTask(CustomAction):
     def _handle_popups(self, messages: list, support_order_mismatch: bool, 
                       team_config_error: bool, state: dict) -> bool:
         """处理弹窗消息列表，返回是否遇到终止弹窗"""
+        manager = get_manager()
         for msg in messages:
             popup_title = msg.get('popup_title', '')
             popup_message = msg.get('popup_message', '')
@@ -444,7 +452,7 @@ class ExecuteBbcTask(CustomAction):
                 mfaalog.info(f"[Callback] 助战弹窗(askyesno)，响应: {action}")
                 
                 if popup_id:
-                    bbc_manager.send_command('popup_response', {
+                    manager.send_command('popup_response', {
                         'popup_id': popup_id,
                         'action': action
                     }, timeout=5)
@@ -466,7 +474,7 @@ class ExecuteBbcTask(CustomAction):
                 mfaalog.info(f"[Callback] 队伍配置弹窗(askokcancel)，响应: {action}")
                 
                 if popup_id:
-                    bbc_manager.send_command('popup_response', {
+                    manager.send_command('popup_response', {
                         'popup_id': popup_id,
                         'action': action
                     }, timeout=5)
@@ -534,7 +542,7 @@ class ExecuteBbcTask(CustomAction):
             time.sleep(heartbeat_interval)
             
             # 心跳检查
-            status = bbc_manager.send_command('get_status', {}, timeout=5)
+            status = manager.send_command('get_status', {}, timeout=5)
             if not status.get('success'):
                 mfaalog.warning("[ExecuteBbcTask] BBC服务无响应")
                 state['finished'] = True

--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -132,7 +132,7 @@ class ExecuteBbcTask(CustomAction):
                 popup_message = msg.get('popup_message', '')
                 mfaalog.info(f"[ExecuteBbcTask] 收到弹窗: {popup_title} - {popup_message}")
                 if not state['finished']:
-                    self._handle_popups([msg], support_order_mismatch, team_config_error, state)
+                    self._handle_popups([msg], support_order_mismatch, team_config_error, state, manager)
                     state['popup_event'].set()  # 通知监听线程
             
             manager.set_popup_callback(on_popup)
@@ -149,7 +149,7 @@ class ExecuteBbcTask(CustomAction):
             # 步骤3: 配置并启动战斗（同时启动回调监听）
             battle_result = self._setup_and_start_battle(
                 team_config, run_count, apple_type, battle_type,
-                support_order_mismatch, team_config_error, state
+                support_order_mismatch, team_config_error, state, manager
             )
             if battle_result is None:
                 manager.disconnect_tcp()
@@ -346,9 +346,7 @@ class ExecuteBbcTask(CustomAction):
     def _setup_and_start_battle(self, team_config: str, run_count: int, 
                                 apple_type: str, battle_type: str,
                                 support_order_mismatch: bool, team_config_error: bool,
-                                state: dict) -> dict:
-        """配置战斗参数并启动，返回 state 或 None"""
-        manager = get_manager()
+                                state: dict, manager) -> dict:
         
         # 回调已在 _execute_single_battle 中设置，这里直接使用
         
@@ -361,7 +359,7 @@ class ExecuteBbcTask(CustomAction):
         
         # 检查配置阶段是否有弹窗
         popup_msgs = manager.get_messages_by_title('', timeout=1)
-        if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state):
+        if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state, manager):
             return state
         
         # 设置参数
@@ -369,7 +367,7 @@ class ExecuteBbcTask(CustomAction):
         manager.send_command('set_apple_type', {'apple_type': apple_type}, timeout=5)
         
         popup_msgs = manager.get_messages_by_title('', timeout=1)
-        if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state):
+        if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state, manager):
             return state
         
         mfaalog.info(f"[ExecuteBbcTask] 设置运行次数: {run_count}")
@@ -380,7 +378,7 @@ class ExecuteBbcTask(CustomAction):
         
         # 启动战斗前最后检查一次弹窗
         popup_msgs = manager.get_messages_by_title('', timeout=1)
-        if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state):
+        if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state, manager):
             return state
         
         # 启动战斗（带重试机制）
@@ -436,9 +434,7 @@ class ExecuteBbcTask(CustomAction):
         return state
     
     def _handle_popups(self, messages: list, support_order_mismatch: bool, 
-                      team_config_error: bool, state: dict) -> bool:
-        """处理弹窗消息列表，返回是否遇到终止弹窗"""
-        manager = get_manager()
+                      team_config_error: bool, state: dict, manager) -> bool:
         for msg in messages:
             popup_title = msg.get('popup_title', '')
             popup_message = msg.get('popup_message', '')

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -142,30 +142,6 @@ class BbcConnectionManager:
         except Exception as e:
             mfaalog.error(f"[BbcConnectionManager] 启动永久监听失败: {e}")
     
-    def _restart_callback_listener(self):
-        """重启回调监听线程，确保绑定到当前实例"""
-        # 停止旧线程
-        with self._state_lock:
-            self._state['callback_listening'] = False
-        
-        if self._callback_server:
-            try:
-                self._callback_server.close()
-            except:
-                pass
-        
-        if self._callback_thread and self._callback_thread.is_alive():
-            self._callback_thread.join(timeout=3)
-        
-        # 创建新的 Event 对象，确保新线程使用全新的同步对象
-        self._bbc_ready_event = threading.Event()
-        mfaalog.info(f"[BbcConnectionManager] 创建新的Event对象, ID: {id(self._bbc_ready_event)}")
-        
-        time.sleep(0.5)
-        
-        # 启动新线程
-        self._start_permanent_listener()
-    
     def _permanent_callback_loop(self, server_sock: socket.socket):
         """永久回调监听主循环 - 将消息放入队列"""
         mfaalog.info("[BbcConnectionManager] 永久回调监听循环开始")

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -658,12 +658,16 @@ class BbcConnectionManager:
 
 # 进程级单例（每个 agent 进程一个实例）
 _manager_instance = None
+_manager_lock = threading.Lock()
 
 def get_manager() -> BbcConnectionManager:
     """获取或创建 BBC 连接管理器实例（进程级单例）"""
     global _manager_instance
     if _manager_instance is None:
-        _manager_instance = BbcConnectionManager()
-        mfaalog.info(f"[BbcConnectionManager] 创建进程级实例, ID: {id(_manager_instance)}")
+        with _manager_lock:
+            # Double-checked locking
+            if _manager_instance is None:
+                _manager_instance = BbcConnectionManager()
+                mfaalog.info(f"[BbcConnectionManager] 创建进程级实例, ID: {id(_manager_instance)}")
     return _manager_instance
 

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -1,5 +1,6 @@
 """
-BBC 连接管理器 - 单例模式，管理 BBC TCP 连接、回调监听、进程启动和模拟器连接
+BBC 连接管理器 - 管理 BBC TCP 连接、回调监听、进程启动和模拟器连接
+每次创建新实例，不使用单例模式
 """
 import json
 import os
@@ -655,5 +656,14 @@ class BbcConnectionManager:
         mfaalog.info("[BbcConnectionManager] TCP连接已清理")
 
 
-# 全局实例
-bbc_manager = BbcConnectionManager()
+# 进程级单例（每个 agent 进程一个实例）
+_manager_instance = None
+
+def get_manager() -> BbcConnectionManager:
+    """获取或创建 BBC 连接管理器实例（进程级单例）"""
+    global _manager_instance
+    if _manager_instance is None:
+        _manager_instance = BbcConnectionManager()
+        mfaalog.info(f"[BbcConnectionManager] 创建进程级实例, ID: {id(_manager_instance)}")
+    return _manager_instance
+

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -54,34 +54,6 @@ class BbcConnectionManager:
         # 自动启动回调监听
         self._start_permanent_listener()
     
-    def _reset_state(self):
-        """重置状态（关闭旧资源）"""
-        # 停止回调监听
-        with self._state_lock:
-            self._state['callback_listening'] = False
-        
-        if self._callback_server:
-            try:
-                self._callback_server.close()
-            except:
-                pass
-        
-        if self._callback_thread and self._callback_thread.is_alive():
-            self._callback_thread.join(timeout=3)
-        
-        # 断开TCP连接
-        self.disconnect_tcp()
-        
-        # 终止BBC进程
-        if self._state.get('bbc_process'):
-            try:
-                self._kill_bbc_process()
-            except:
-                pass
-        
-        time.sleep(0.5)
-        mfaalog.info("[BbcConnectionManager] 旧状态已清理")
-    
     def _cleanup_port(self):
         """清理端口上的旧监听（通过查找并终止占用端口的进程）"""
         try:

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -613,6 +613,5 @@ def get_manager() -> BbcConnectionManager:
             # Double-checked locking
             if _manager_instance is None:
                 _manager_instance = BbcConnectionManager()
-                mfaalog.info(f"[BbcConnectionManager] 创建进程级实例, ID: {id(_manager_instance)}")
     return _manager_instance
 

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -85,7 +85,6 @@ class BbcConnectionManager:
     def _cleanup_port(self):
         """清理端口上的旧监听（通过查找并终止占用端口的进程）"""
         try:
-            import subprocess
             # Windows: 查找占用端口的 PID
             result = subprocess.run(
                 ['netstat', '-ano'],
@@ -96,7 +95,7 @@ class BbcConnectionManager:
             )
             
             if not result.stdout:
-                mfaalog.debug(f"[BbcConnectionManager] netstat 返回空")
+                mfaalog.debug("[BbcConnectionManager] netstat 返回空")
                 return
             
             for line in result.stdout.splitlines():

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -415,7 +415,7 @@ class BbcConnectionManager:
     # ==================== BBC 进程管理 ====================
     
     def _find_bbc_process(self):
-        """查找BBC进程"""
+        """查找BBC进程（私有方法）"""
         try:
             for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
                 try:
@@ -428,6 +428,10 @@ class BbcConnectionManager:
         except Exception as e:
             mfaalog.warning(f"[BbcConnectionManager] 查找进程失败: {e}")
             return None
+    
+    def find_bbc_process(self):
+        """查找BBC进程（公共接口）"""
+        return self._find_bbc_process()
     
     def _kill_bbc_process(self, proc=None):
         """终止BBC进程"""

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -28,22 +28,11 @@ BBC_EXE_PATH = os.path.abspath(BBC_EXE_PATH)
 
 
 class BbcConnectionManager:
-    """BBC 连接管理器 - 单例"""
-    
-    _instance = None
-    _lock = threading.Lock()
-    
-    def __new__(cls):
-        if cls._instance is None:
-            with cls._lock:
-                if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._initialized = False
-        return cls._instance
+    """BBC 连接管理器 - 每次创建新实例"""
     
     def __init__(self):
-        if self._initialized:
-            return
+        # 先尝试关闭端口上的旧监听（如果有）
+        self._cleanup_port()
         
         self._tcp_sock: Optional[socket.socket] = None
         self._callback_server: Optional[socket.socket] = None
@@ -51,6 +40,7 @@ class BbcConnectionManager:
         self._message_queue = []  # 消息队列
         self._queue_lock = threading.Lock()
         self._popup_callback = None  # 弹窗回调函数
+        self._bbc_ready_event = threading.Event()  # BBC就绪事件
         self._state = {
             'connected': False,
             'callback_listening': False,
@@ -58,11 +48,74 @@ class BbcConnectionManager:
         }
         self._state_lock = threading.Lock()
         
-        self._initialized = True
-        mfaalog.info("[BbcConnectionManager] 初始化完成")
+        mfaalog.info(f"[BbcConnectionManager] 创建新实例, ID: {id(self)}, Event ID: {id(self._bbc_ready_event)}")
         
         # 自动启动回调监听
         self._start_permanent_listener()
+    
+    def _reset_state(self):
+        """重置状态（关闭旧资源）"""
+        # 停止回调监听
+        with self._state_lock:
+            self._state['callback_listening'] = False
+        
+        if self._callback_server:
+            try:
+                self._callback_server.close()
+            except:
+                pass
+        
+        if self._callback_thread and self._callback_thread.is_alive():
+            self._callback_thread.join(timeout=3)
+        
+        # 断开TCP连接
+        self.disconnect_tcp()
+        
+        # 终止BBC进程
+        if self._state.get('bbc_process'):
+            try:
+                self._kill_bbc_process()
+            except:
+                pass
+        
+        time.sleep(0.5)
+        mfaalog.info("[BbcConnectionManager] 旧状态已清理")
+    
+    def _cleanup_port(self):
+        """清理端口上的旧监听（通过查找并终止占用端口的进程）"""
+        try:
+            import subprocess
+            # Windows: 查找占用端口的 PID
+            result = subprocess.run(
+                ['netstat', '-ano'],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                encoding='gbk'  # Windows netstat 输出是 GBK 编码
+            )
+            
+            if not result.stdout:
+                mfaalog.debug(f"[BbcConnectionManager] netstat 返回空")
+                return
+            
+            for line in result.stdout.splitlines():
+                if f':{BBC_CALLBACK_PORT}' in line and 'LISTENING' in line:
+                    parts = line.strip().split()
+                    if len(parts) >= 5:
+                        pid = parts[-1]
+                        mfaalog.warning(f"[BbcConnectionManager] 检测到端口 {BBC_CALLBACK_PORT} 被 PID {pid} 占用，终止进程...")
+                        try:
+                            subprocess.run(['taskkill', '/F', '/PID', pid], 
+                                         capture_output=True, timeout=3)
+                            mfaalog.info(f"[BbcConnectionManager] 已终止 PID {pid}")
+                            time.sleep(0.5)
+                        except Exception as e:
+                            mfaalog.error(f"[BbcConnectionManager] 终止进程失败: {e}")
+                    break
+            else:
+                mfaalog.info(f"[BbcConnectionManager] 端口 {BBC_CALLBACK_PORT} 空闲")
+        except Exception as e:
+            mfaalog.warning(f"[BbcConnectionManager] 端口检查异常: {e}")
     
     def _start_permanent_listener(self):
         """启动永久回调监听（后台线程）"""
@@ -87,6 +140,30 @@ class BbcConnectionManager:
             mfaalog.info(f"[BbcConnectionManager] 永久回调监听已启动 on port {BBC_CALLBACK_PORT}")
         except Exception as e:
             mfaalog.error(f"[BbcConnectionManager] 启动永久监听失败: {e}")
+    
+    def _restart_callback_listener(self):
+        """重启回调监听线程，确保绑定到当前实例"""
+        # 停止旧线程
+        with self._state_lock:
+            self._state['callback_listening'] = False
+        
+        if self._callback_server:
+            try:
+                self._callback_server.close()
+            except:
+                pass
+        
+        if self._callback_thread and self._callback_thread.is_alive():
+            self._callback_thread.join(timeout=3)
+        
+        # 创建新的 Event 对象，确保新线程使用全新的同步对象
+        self._bbc_ready_event = threading.Event()
+        mfaalog.info(f"[BbcConnectionManager] 创建新的Event对象, ID: {id(self._bbc_ready_event)}")
+        
+        time.sleep(0.5)
+        
+        # 启动新线程
+        self._start_permanent_listener()
     
     def _permanent_callback_loop(self, server_sock: socket.socket):
         """永久回调监听主循环 - 将消息放入队列"""
@@ -115,6 +192,12 @@ class BbcConnectionManager:
                 
                 msg = json.loads(data.decode('utf-8'))
                 
+                # 处理关闭信号
+                if msg.get('event') == '__shutdown__':
+                    mfaalog.info(f"[BbcConnectionManager] 收到关闭信号，退出回调线程")
+                    client_sock.close()
+                    break
+                
                 # 根据事件类型输出日志
                 event = msg.get('event')
                 if event == 'popup_show':
@@ -123,6 +206,12 @@ class BbcConnectionManager:
                     mfaalog.debug(f"[BbcConnectionManager] 弹窗已关闭: {msg.get('popup_title', '')}")
                 else:
                     mfaalog.debug(f"[BbcConnectionManager] 收到回调: {msg}")
+                
+                # 触发BBC就绪事件
+                if event in ['server_started', 'disclaimer_closed']:
+                    mfaalog.info(f"[BbcConnectionManager] BBC就绪信号: {event}, Event对象ID: {id(self._bbc_ready_event)}, Event状态: {self._bbc_ready_event.is_set()}")
+                    self._bbc_ready_event.set()
+                    mfaalog.info(f"[BbcConnectionManager] 已触发事件, Event状态: {self._bbc_ready_event.is_set()}")
                 
                 # 放入消息队列
                 with self._queue_lock:
@@ -397,19 +486,16 @@ class BbcConnectionManager:
             return None
     
     def _wait_for_bbc_ready(self, timeout: int = 30) -> bool:
-        """从消息队列等待 BBC 就绪信号"""
-        start_time = time.time()
+        """等待 BBC 就绪信号"""
+        mfaalog.info(f"[BbcConnectionManager] 等待BBC就绪 (超时{timeout}s)...")
+        ready = self._bbc_ready_event.wait(timeout=timeout)
         
-        while time.time() - start_time < timeout:
-            msg = self.get_message(timeout=0.5)
-            if msg:
-                event = msg.get('event', '')
-                if event in ['server_started', 'disclaimer_closed']:
-                    mfaalog.info(f"[BbcConnectionManager] BBC 就绪事件: {event}")
-                    return True
-        
-        mfaalog.warning(f"[BbcConnectionManager] 等待 BBC 就绪超时 ({timeout}s)")
-        return False
+        if ready:
+            mfaalog.info("[BbcConnectionManager] BBC 就绪事件已触发")
+            return True
+        else:
+            mfaalog.warning(f"[BbcConnectionManager] 等待 BBC 就绪超时 ({timeout}s)")
+            return False
     
     # ==================== 模拟器连接 ====================
     
@@ -462,7 +548,13 @@ class BbcConnectionManager:
         for attempt in range(1, max_retries + 1):
             mfaalog.info(f"[BbcConnectionManager] 第{attempt}次启动尝试")
             
+            # 清空本次尝试的消息队列和就绪事件
+            mfaalog.info(f"[BbcConnectionManager] 清空消息队列和就绪事件 (尝试 {attempt})")
+            self.clear_message_queue()
+            self._bbc_ready_event.clear()
+            
             # 1. 杀掉旧进程
+            mfaalog.info(f"[BbcConnectionManager] 终止旧BBC进程 (尝试 {attempt})")
             self._kill_bbc_process()
             time.sleep(5)
             

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -193,12 +193,6 @@ class BbcConnectionManager:
                 
                 msg = json.loads(data.decode('utf-8'))
                 
-                # 处理关闭信号
-                if msg.get('event') == '__shutdown__':
-                    mfaalog.info(f"[BbcConnectionManager] 收到关闭信号，退出回调线程")
-                    client_sock.close()
-                    break
-                
                 # 根据事件类型输出日志
                 event = msg.get('event')
                 if event == 'popup_show':

--- a/agent/custom/bbc_start.py
+++ b/agent/custom/bbc_start.py
@@ -10,7 +10,7 @@ _custom_dir = os.path.dirname(os.path.abspath(__file__))
 if _custom_dir not in sys.path:
     sys.path.insert(0, _custom_dir)
 
-from bbc_connection_manager import bbc_manager
+from bbc_connection_manager import get_manager
 import mfaalog
 
 
@@ -80,15 +80,18 @@ class StartBbc(CustomAction):
             
             # 步骤1: 检查BBC进程是否存在
             mfaalog.info("[StartBbc] 步骤1: 检查BBC状态...")
-            bbc_proc = bbc_manager._find_bbc_process()
+            
+            # 获取或创建 Manager 实例（进程级单例）
+            manager = get_manager()
+            bbc_proc = manager._find_bbc_process()
             
             if bbc_proc:
                 mfaalog.info(f"[StartBbc] 发现BBC进程，PID: {bbc_proc.pid}")
                 # 检查Manager是否已连接
-                if bbc_manager.ensure_connected(timeout=3):
+                if manager.ensure_connected(timeout=3):
                     mfaalog.info("[StartBbc] Manager已连接，检查模拟器状态...")
                     # 先检查模拟器是否已经连接
-                    conn_result = bbc_manager.send_command('get_connection', {}, timeout=5)
+                    conn_result = manager.send_command('get_connection', {}, timeout=5)
                     mfaalog.info(f"[StartBbc] get_connection 返回: {conn_result}")
                     
                     # 检查返回结果中是否有模拟器连接信息
@@ -103,7 +106,7 @@ class StartBbc(CustomAction):
                         # 有模拟器参数说明已连接到具体模拟器，检查是否与配置匹配
                         if (connected or available) and emulator_params:
                             # 根据连接类型检查参数是否匹配
-                            params_match = bbc_manager.check_emulator_params_match(connect_cmd, connect_args, emulator_params)
+                            params_match = manager.check_emulator_params_match(connect_cmd, connect_args, emulator_params)
                             if params_match:
                                 emulator_ready = True
                                 mfaalog.info(f"[StartBbc] 模拟器已连接且参数匹配: {emulator_params}")
@@ -131,7 +134,7 @@ class StartBbc(CustomAction):
             
             # 步骤3: 调用Manager的完整重启流程
             mfaalog.info("[StartBbc] 步骤3: 调用Manager重启BBC并连接模拟器...")
-            success = bbc_manager.restart_bbc_and_connect(connect_cmd, connect_args, max_retries=5)
+            success = manager.restart_bbc_and_connect(connect_cmd, connect_args, max_retries=5)
             
             if success:
                 mfaalog.info("[StartBbc] BBC启动并连接成功")

--- a/agent/custom/bbc_start.py
+++ b/agent/custom/bbc_start.py
@@ -83,7 +83,7 @@ class StartBbc(CustomAction):
             
             # 获取或创建 Manager 实例（进程级单例）
             manager = get_manager()
-            bbc_proc = manager._find_bbc_process()
+            bbc_proc = manager.find_bbc_process()
             
             if bbc_proc:
                 mfaalog.info(f"[StartBbc] 发现BBC进程，PID: {bbc_proc.pid}")


### PR DESCRIPTION
- 移除单例模式，每次任务启动创建新Manager实例
- 添加_cleanup_port()方法，启动前强制终止占用25002端口的进程
- 修复netstat编码问题（Windows需GBK编码）
- 解决多任务连续启动时回调Event对象不一致导致的超时问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 更新说明

* **重构**
  * 引入进程级管理器与实例就绪信号，改进启动/重启与回调监听的生命周期管理，减少端口占用与残留进程。
* **新功能**
  * 增加对运行中 BBC 进程的检测入口，便于更可靠地发现并处理本地进程状态。
* **修复**
  * 提升弹窗与回调处理稳定性，改进重试与恢复流程，减少丢失响应和连接失败。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->