### PR TITLE
Fix/bbc tcp server stability

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,17 @@
-# coderabbit.yml
-language: "zh_CN"     # 设置审查意见为中文
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# ==================== 基础设置（官方支持字段）====================
+language: "zh-CN"                  # 强制中文回复
+
+# ==================== 审查行为设置（官方允许字段）====================
 reviews:
-  profile: "assertive"    # 审查严格度：chill(宽松), assertive(自信/适中), aggressive(严苛)
+  profile: "assertive"             # 严格审查模式（chill/assertive）
   auto_review:
-    enabled: true      # 开启自动审查
+    enabled: true                  # 启用自动审查
+    drafts: false                  # 不审查草稿PR
+  
+# ==================== 对话/交互设置（官方支持字段）====================
+chat:
+  auto_reply: true                 # 启用自动回复
+  art: true                        # 在聊天回复中生成艺术（ASCII或表情符号）
+  allow_non_org_members: true      # 允许非组织成员与CodeRabbit交互

--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -12,6 +12,7 @@ if _custom_dir not in sys.path:
     sys.path.insert(0, _custom_dir)
 
 from bbc_connection_manager import get_manager
+from bbc_emulator_utils import get_connect_command_and_args
 import mfaalog
 
 
@@ -21,7 +22,18 @@ class ExecuteBbcTask(CustomAction):
     """执行BBC战斗任务 - 事件驱动模式"""
 
     def run(self, context: Context, argv: CustomAction.RunArg) -> CustomAction.RunResult:
-        """主入口：带自动重启的战斗流程"""
+        """
+        执行 BBC 战斗任务，支持最多两次尝试，两次尝试之间可选重启 BBC。
+
+        如果单次尝试信号需要重启，则重启 BBC 并重试。 最终失败时，格式化错误信息写入 pipeline 节点 "bbc弹窗信息输出"。
+
+        参数:
+            context (Context): MAA 上下文对象。
+            argv (CustomAction.RunArg): 运行时参数。
+
+        返回:
+            CustomAction.RunResult: 战斗成功完成返回 `success=True`，否则返回 `success=False`。
+        """
         max_retries = 2  # 最多重试2次
         last_error = None
         
@@ -69,7 +81,21 @@ class ExecuteBbcTask(CustomAction):
         return CustomAction.RunResult(success=False)
     
     def _execute_single_battle(self, context: Context) -> dict:
-        """执行单次战斗流程（不含重启逻辑）"""
+        """
+        使用当前节点的 attach 数据执行单次 BBC 战斗流程，不执行任何 BBC 进程重启。
+
+        执行连接验证、模拟器校验、战斗配置/启动、弹窗事件处理，并等待战斗完成。
+        完成后可通过 context.override_pipeline 将弹窗信息写入 pipeline（键为 "bbc弹窗信息输出"）。
+
+        参数:
+            context (Context): MAA 上下文对象。
+
+        返回:
+            dict: 结果对象，包含以下键：
+                - 'success' (bool): 战斗无错误弹窗完成时为 `True`，否则为 `False`。
+                - 'error' (str, 可选): 'success' 为 `False` 时的错误信息。
+                - 'need_restart' (bool, 可选): 结果表明需要重启 BBC 进程时为 `True`（例如错误弹窗或检测到服务故障），否则为 `False` 或省略。
+        """
         try:
             # 从 Context 获取节点数据
             node_data = context.get_node_data("执行BBC任务")
@@ -98,25 +124,12 @@ class ExecuteBbcTask(CustomAction):
             run_count = int(run_count)
             mfaalog.info(f"[ExecuteBbcTask] 参数: team={team_config}, count={run_count}, apple={apple_type}, type={battle_type}")
             
-            # 提前创建共享状态并启动监听线程
-            popup_event = threading.Event()
+            # 提前创建共享状态
             state = {
                 'finished': False,
                 'popup_title': '',
-                'popup_message': '',
-                'popup_event': popup_event
+                'popup_message': ''
             }
-            
-            # 启动弹窗监听线程（在 action 开头启动，确保能捕获所有弹窗）
-            def popup_listener():
-                while not state['finished']:
-                    popup_event.wait()  # 无限等待弹窗
-                    popup_event.clear()
-                    mfaalog.info("[ExecuteBbcTask] 弹窗监听线程收到通知")
-            
-            listener_thread = threading.Thread(target=popup_listener, daemon=True)
-            listener_thread.start()
-            mfaalog.info("[ExecuteBbcTask] 弹窗监听线程已启动")
             
             # 获取或创建 Manager 实例（进程级单例）
             manager = get_manager()
@@ -127,13 +140,20 @@ class ExecuteBbcTask(CustomAction):
             
             # 提前设置弹窗回调（在清空队列之前，确保不会错过弹窗）
             def on_popup(msg):
-                """弹窗回调函数 - 快速返回，不阻塞监听线程"""
+                """
+                当战斗未结束时，将收到的弹窗消息委托给弹窗处理器。
+
+                参数:
+                    msg (dict): 弹窗消息，包含 'popup_title'、'popup_message'、'popup_id' 等键。
+                """
                 popup_title = msg.get('popup_title', '')
                 popup_message = msg.get('popup_message', '')
                 mfaalog.info(f"[ExecuteBbcTask] 收到弹窗: {popup_title} - {popup_message}")
                 if not state['finished']:
                     self._handle_popups([msg], support_order_mismatch, team_config_error, state, manager)
-                    state['popup_event'].set()  # 通知监听线程
+                    # Check if state became finished after handling to avoid further work
+                    if state['finished']:
+                        return
             
             manager.set_popup_callback(on_popup)
             mfaalog.info("[ExecuteBbcTask] 弹窗回调已设置")
@@ -154,7 +174,12 @@ class ExecuteBbcTask(CustomAction):
             if battle_result is None:
                 manager.disconnect_tcp()
                 return {'success': False, 'error': '战斗启动失败'}
-            
+
+            # Check if battle_result is a failure dict with success==False
+            if isinstance(battle_result, dict) and not battle_result.get('success', True):
+                manager.disconnect_tcp()
+                return battle_result  # Preserve 'need_restart' and 'error'
+
             # 步骤4: 等待战斗结束
             popup_title, popup_message = self._wait_for_battle_end(state, manager)
             
@@ -175,6 +200,14 @@ class ExecuteBbcTask(CustomAction):
                 mfaalog.info("[ExecuteBbcTask] 战斗正常结束")
             
             # 返回结果和是否需要重启的标志
+            # 如果是用户主动停止，不算成功
+            if state.get('user_stopped'):
+                return {
+                    'success': False,
+                    'error': f"{popup_title}: {popup_message}" if popup_title or popup_message else "用户主动停止",
+                    'need_restart': False  # 用户主动停止不需要重启
+                }
+
             # 如果是错误状态，标记为失败
             if popup_title == '错误' or '错误' in (popup_message or ''):
                 return {
@@ -182,7 +215,7 @@ class ExecuteBbcTask(CustomAction):
                     'error': f"{popup_title}: {popup_message}",
                     'need_restart': True  # 错误状态需要重启
                 }
-            
+
             return {
                 'success': True,
                 'need_restart': state.get('need_restart', False)
@@ -194,7 +227,15 @@ class ExecuteBbcTask(CustomAction):
             return {'success': False, 'error': error_msg}
     
     def _restart_bbc(self, context: Context) -> bool:
-        """重启BBC进程"""
+        """
+        通过停止再启动 BBC pipeline 任务来重启 BBC 服务。
+
+        参数:
+            context (Context): MAA 上下文对象。
+
+        返回:
+            bool: 重启成功返回 `True`，否则返回 `False`。
+        """
         manager = get_manager()
         try:
             # 先断开当前连接
@@ -225,7 +266,15 @@ class ExecuteBbcTask(CustomAction):
             return False
     
     def _ensure_bbc_connected(self, context: Context):
-        """确保BBC已连接，必要时触发bbc_start"""
+        """
+        确保与 BBC 服务的 TCP 连接已建立，若未连接则触发 pipeline 节点 "启动bbc"。
+
+        参数:
+            context (Context): MAA 上下文对象。
+
+        返回:
+            bool: TCP 连接建立成功返回 `True`，否则返回 `False`。
+        """
         manager = get_manager()
         # 检查连接是否有效
         if manager.ensure_connected(timeout=3):
@@ -250,45 +299,27 @@ class ExecuteBbcTask(CustomAction):
         return False
     
     def _verify_emulator_connection(self, attach_data: dict, context: Context) -> bool:
-        """验证模拟器连接，必要时调用Manager重启"""
+        """
+        验证模拟器参数是否与预期配置匹配，若参数缺失或不匹配则尝试重启 BBC 并使用 manager 的重连逻辑重新连接。
+
+        参数:
+            attach_data (dict): 预期连接配置（包含连接模式和特定provider的参数如 MuMu/LD/ADB 参数），用于构建预期的连接命令和参数。
+            context (Context): 动作上下文（传递给任务执行）。
+
+        返回:
+            bool: 模拟器参数匹配预期配置，或 manager 成功重启 BBC 并重连时返回 `True`，否则返回 `False`。
+        """
         manager = get_manager()
         conn_status = manager.send_command('get_connection', {}, timeout=5)
-        
+
         # 检查是否有模拟器参数
         device_info = conn_status.get('device_info', {})
         emulator_params = device_info.get('emulator_params', {})
-        
+
+        # 提取用户配置的参数（使用共享helper）
+        connect_cmd, expected_args = get_connect_command_and_args(attach_data)
+
         if emulator_params:
-            # 提取用户配置的参数
-            connect = attach_data.get('connect', 'auto')
-            connect_cmd_map = {
-                'mumu': 'connect_mumu',
-                'ld': 'connect_ld',
-                'adb': 'connect_adb',
-                'connect_mumu': 'connect_mumu',
-                'connect_ld': 'connect_ld',
-                'connect_adb': 'connect_adb'
-            }
-            connect_cmd = connect_cmd_map.get(connect, connect)
-            
-            expected_args = {}
-            if connect_cmd == 'connect_mumu':
-                expected_args = {
-                    'path': attach_data.get('mumu_path', ''),
-                    'index': int(attach_data.get('mumu_index', 0)),
-                    'pkg': attach_data.get('mumu_pkg', 'com.bilibili.fatego'),
-                    'app_index': int(attach_data.get('mumu_app_index', 0))
-                }
-            elif connect_cmd == 'connect_ld':
-                expected_args = {
-                    'path': attach_data.get('ld_path', ''),
-                    'index': int(attach_data.get('ld_index', 0))
-                }
-            elif connect_cmd == 'connect_adb':
-                expected_args = {
-                    'ip': attach_data.get('manual_port', '')
-                }
-            
             # 检查参数是否匹配
             params_match = manager.check_emulator_params_match(connect_cmd, expected_args, emulator_params)
             if params_match:
@@ -296,46 +327,12 @@ class ExecuteBbcTask(CustomAction):
                 return True
             else:
                 mfaalog.warning(f"[ExecuteBbcTask] 模拟器参数不匹配，期望: {expected_args}, 实际: {emulator_params}")
-        
+
         mfaalog.warning("[ExecuteBbcTask] 模拟器未连接或参数不匹配，调用Manager重启BBC...")
-        
-        # 提取连接参数
-        connect = attach_data.get('connect', 'auto')
-        connect_cmd_map = {
-            'mumu': 'connect_mumu',
-            'ld': 'connect_ld',
-            'adb': 'connect_adb',
-            'connect_mumu': 'connect_mumu',
-            'connect_ld': 'connect_ld',
-            'connect_adb': 'connect_adb'
-        }
-        connect_cmd = connect_cmd_map.get(connect, connect)
-        
-        connect_args = {}
-        if connect_cmd == 'connect_mumu':
-            connect_args = {
-                'path': attach_data.get('mumu_path', ''),
-                'index': int(attach_data.get('mumu_index', 0)),
-                'pkg': attach_data.get('mumu_pkg', 'com.bilibili.fatego'),
-                'app_index': int(attach_data.get('mumu_app_index', 0))
-            }
-        elif connect_cmd == 'connect_ld':
-            connect_args = {
-                'path': attach_data.get('ld_path', ''),
-                'index': int(attach_data.get('ld_index', 0))
-            }
-        elif connect_cmd == 'connect_adb':
-            connect_args = {
-                'ip': attach_data.get('manual_port', '')
-            }
-        elif connect_cmd == 'auto':
-            connect_args = {
-                'mode': 'auto'
-            }
-        
+
         # 调用Manager的完整重启流程
-        success = manager.restart_bbc_and_connect(connect_cmd, connect_args, max_retries=3)
-        
+        success = manager.restart_bbc_and_connect(connect_cmd, expected_args, max_retries=3)
+
         if success:
             mfaalog.info("[ExecuteBbcTask] BBC重启并连接成功")
             return True
@@ -343,13 +340,32 @@ class ExecuteBbcTask(CustomAction):
             mfaalog.error("[ExecuteBbcTask] BBC重启失败")
             return False
     
-    def _setup_and_start_battle(self, team_config: str, run_count: int, 
+    def _setup_and_start_battle(self, team_config: str, run_count: int,
                                 apple_type: str, battle_type: str,
                                 support_order_mismatch: bool, team_config_error: bool,
                                 state: dict, manager) -> dict:
-        
+        """
+        准备战斗配置、应用参数、启动战斗并返回共享状态。
+
+        加载配置文件、设置苹果类型、运行次数、战斗类型，然后发送启动命令。战斗开始后返回共享的 state 字典。
+
+        参数:
+            team_config (str): 要加载的队伍配置文件的文件名或标识符。
+            run_count (int): 战斗运行次数。
+            apple_type (str): 启动前应用的苹果类型设置。
+            battle_type (str): 要应用的战斗模式标签（例如 "连续出击"）。
+            support_order_mismatch (bool): 若为 True，自动接受助战排序不匹配的弹窗；若为 False，遇到弹窗时停止并设置 `state`。
+            team_config_error (bool): 若为 True，自动接受队伍配置错误的弹窗；若为 False，遇到弹窗时停止并设置 `state`。
+            state (dict): 用于协调弹窗处理和信号完成的共享可变状态；此函数可能修改 'finished'、'popup_title'、'popup_message'、'need_restart' 等键。
+            manager: 用于发送命令和查询 UI/消息的外部 BBC/连接管理器。
+
+        返回:
+            dict 或 None: 战斗已启动且完成处理在其他地方时返回共享的 `state` 字典。
+            在不可恢复的设置/启动失败时返回 None（例如加载配置失败或启动命令错误）。
+            当启动确定失败且建议重启时，可能返回 `{'success': False, 'error': <message>, 'need_restart': True}`。
+        """
         # 回调已在 _execute_single_battle 中设置，这里直接使用
-        
+
         # 加载配置
         mfaalog.info(f"[ExecuteBbcTask] 加载配置: {team_config}")
         result = manager.send_command('load_config', {'filename': team_config}, timeout=10)
@@ -364,17 +380,38 @@ class ExecuteBbcTask(CustomAction):
         
         # 设置参数
         mfaalog.info(f"[ExecuteBbcTask] 设置苹果类型: {apple_type}")
-        manager.send_command('set_apple_type', {'apple_type': apple_type}, timeout=5)
-        
+        result = manager.send_command('set_apple_type', {'apple_type': apple_type}, timeout=5)
+        if not result.get('success'):
+            error_msg = f"set_apple_type RPC failed: {result.get('error', 'unknown error')}, payload: {result}"
+            mfaalog.error(f"[ExecuteBbcTask] {error_msg}")
+            state['finished'] = True
+            state['popup_title'] = '错误'
+            state['popup_message'] = error_msg
+            return state
+
         popup_msgs = manager.get_messages_by_title('', timeout=1)
         if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state, manager):
             return state
-        
+
         mfaalog.info(f"[ExecuteBbcTask] 设置运行次数: {run_count}")
-        manager.send_command('set_run_times', {'times': run_count}, timeout=5)
-        
+        result = manager.send_command('set_run_times', {'times': run_count}, timeout=5)
+        if not result.get('success'):
+            error_msg = f"set_run_times RPC failed: {result.get('error', 'unknown error')}, payload: {result}"
+            mfaalog.error(f"[ExecuteBbcTask] {error_msg}")
+            state['finished'] = True
+            state['popup_title'] = '错误'
+            state['popup_message'] = error_msg
+            return state
+
         mfaalog.info(f"[ExecuteBbcTask] 设置战斗类型: {battle_type}")
-        manager.send_command('set_battle_type', {'battle_type': battle_type}, timeout=5)
+        result = manager.send_command('set_battle_type', {'battle_type': battle_type}, timeout=5)
+        if not result.get('success'):
+            error_msg = f"set_battle_type RPC failed: {result.get('error', 'unknown error')}, payload: {result}"
+            mfaalog.error(f"[ExecuteBbcTask] {error_msg}")
+            state['finished'] = True
+            state['popup_title'] = '错误'
+            state['popup_message'] = error_msg
+            return state
         
         # 启动战斗前最后检查一次弹窗
         popup_msgs = manager.get_messages_by_title('', timeout=1)
@@ -421,20 +458,47 @@ class ExecuteBbcTask(CustomAction):
                 continue
             
             # 检查是否有其他弹窗
-            popup_msgs = manager.get_messages_by_title('', timeout=2)
-            if popup_msgs:
-                mfaalog.info(f"[ExecuteBbcTask] 检测到弹窗: {popup_msgs[0].get('popup_title', '')}")
+            if not state['finished']:
+                popup_msgs = manager.get_messages_by_title('', timeout=2)
+                if popup_msgs:
+                    mfaalog.info(f"[ExecuteBbcTask] 检测到弹窗: {popup_msgs[0].get('popup_title', '')}")
+                    # Handle the queued popup and check if it finished the run
+                    if self._handle_popups(popup_msgs, support_order_mismatch, team_config_error, state, manager):
+                        # Run has finished, stop retrying
+                        return state
         
         if not battle_started:
             error_msg = "启动战斗失败（阵容未设置，已重试3次）"
             mfaalog.error(f"[ExecuteBbcTask] {error_msg}")
-            return {'success': False, 'error': error_msg, 'need_restart': True}
-        
+            failure_result = {'success': False, 'error': error_msg, 'need_restart': True}
+            # Check if this failure result should short-circuit in _execute_single_battle
+            if isinstance(failure_result, dict) and not failure_result.get('success', True):
+                return failure_result  # Preserve 'need_restart' and 'error'
+
         mfaalog.info("[ExecuteBbcTask] 战斗已启动，等待结束...")
         return state
     
-    def _handle_popups(self, messages: list, support_order_mismatch: bool, 
+    def _handle_popups(self, messages: list, support_order_mismatch: bool,
                       team_config_error: bool, state: dict, manager) -> bool:
+        """
+        处理 BBC 弹窗消息并根据情况更新共享状态。
+
+        处理已知弹窗类别（助战排序不匹配、队伍配置错误、脚本停止、任务/其他运行通知），通过 manager 可选发送弹窗响应，并设置 state 字段以指示完成状态和任何错误/重启需求。
+
+        参数:
+            messages (list): 弹窗消息字典列表；每个可能包含 'popup_title'、'popup_message'、'popup_id'。
+            support_order_mismatch (bool): 对 "助战排序不符合" 弹窗的操作；True 继续，False 停止。
+            team_config_error (bool): 对 "队伍配置错误" 弹窗的操作；True 继续，False 停止。
+            state (dict): 此函数修改的共享状态。可能更新的键：
+                - 'finished' (bool): 处理确定运行应该结束时设为 True。
+                - 'popup_title' (str): 导致终止的弹窗标题（如果有）。
+                - 'popup_message' (str): 导致终止的弹窗消息文本（如果有）。
+                - 'need_restart' (bool): 当需要 BBC 重启的崩溃条件时设为 True。
+            manager: BBC 管理器，用于通过 'popup_response' 命令发送弹窗响应。
+
+        返回:
+            bool: 处理消息导致运行结束时（设置了 state['finished']）返回 `True`，否则返回 `False`。
+        """
         for msg in messages:
             popup_title = msg.get('popup_title', '')
             popup_message = msg.get('popup_message', '')
@@ -457,6 +521,9 @@ class ExecuteBbcTask(CustomAction):
                     state['finished'] = True
                     state['popup_title'] = popup_title
                     state['popup_message'] = popup_message
+                    state['user_stopped'] = True  # 用户主动停止，不算成功
+                    if 'finished_event' in state:
+                        state['finished_event'].set()
                     mfaalog.info("[Callback] 用户拒绝助战，战斗结束")
                     return True
                 else:  # True = 继续
@@ -479,6 +546,9 @@ class ExecuteBbcTask(CustomAction):
                     state['finished'] = True
                     state['popup_title'] = popup_title
                     state['popup_message'] = popup_message
+                    state['user_stopped'] = True  # 用户主动停止，不算成功
+                    if 'finished_event' in state:
+                        state['finished_event'].set()
                     mfaalog.info("[Callback] 用户拒绝队伍配置，战斗结束")
                     return True
                 else:  # True = 继续
@@ -501,23 +571,29 @@ class ExecuteBbcTask(CustomAction):
                     state['popup_title'] = '游戏异常'
                     state['popup_message'] = popup_message
                     state['need_restart'] = True  # 标记需要重启
+                    if 'finished_event' in state:
+                        state['finished_event'].set()
                     return True
                 else:
                     mfaalog.info("[Callback] 任务正常结束")
                     # 正常结束不设置弹窗信息，避免被误判为异常
                     state['finished'] = True
+                    if 'finished_event' in state:
+                        state['finished_event'].set()
                     return True
             
             # 处理其他单按钮弹窗 (showwarning/showerror/showinfo 类型，BBC Server自动关闭)
             elif any(keyword in popup_title for keyword in ['正在结束任务', '其他任务运行中']):
                 mfaalog.info(f"[Callback] 检测到提示弹窗: {popup_title}")
-                
+
                 state['finished'] = True
                 state['popup_title'] = popup_title
                 state['popup_message'] = popup_message
+                if 'finished_event' in state:
+                    state['finished_event'].set()
                 mfaalog.info("[Callback] 提示弹窗已处理，战斗结束")
                 return True
-            
+
             # 处理未知弹窗（兜底）
             else:
                 mfaalog.warning(f"[Callback] 未知弹窗: {popup_title}")
@@ -525,18 +601,43 @@ class ExecuteBbcTask(CustomAction):
                 state['finished'] = True
                 state['popup_title'] = popup_title
                 state['popup_message'] = popup_message
+                if 'finished_event' in state:
+                    state['finished_event'].set()
                 return True
         
         return False
     
     def _wait_for_battle_end(self, state: dict, manager):
-        """等待战斗结束 - 心跳检查和弹窗处理分离"""
-        
+        """
+        阻塞等待战斗流程结束，通过定期 manager 心跳检测服务故障。
+
+        参数:
+            state (dict): 共享状态字典，包含键：
+                - 'finished' (bool): 设为 True 以结束等待。
+                - 'popup_title' (str|None): 发生终端弹窗时填充。
+                - 'popup_message' (str|None): 发生终端弹窗时填充。
+                - 'need_restart' (bool, 可选): 失败时可能设为请求 BBC 重启。
+                - 'finished_event' (threading.Event): 弹窗处理器在 finished 变化时设置的事件。
+            manager: BBC 连接管理器，用于通过 `send_command('get_status', ...)` 执行心跳检查。
+
+        返回:
+            tuple: (popup_title, popup_message) - 保存在 `state` 中的最终弹窗标题和消息。
+        """
+
         # 主线程：只做心跳检查
         heartbeat_interval = 30  # 30秒一次心跳
+        finished_event = state.get('finished_event')
+        if finished_event is None:
+            finished_event = threading.Event()
+            state['finished_event'] = finished_event
+
         while not state['finished']:
-            time.sleep(heartbeat_interval)
-            
+            # Wait on event with timeout; if set early we wake immediately
+            finished_event.wait(timeout=heartbeat_interval)
+
+            if state['finished']:
+                break
+
             # 心跳检查
             status = manager.send_command('get_status', {}, timeout=5)
             if not status.get('success'):
@@ -545,9 +646,10 @@ class ExecuteBbcTask(CustomAction):
                 state['popup_title'] = '错误'
                 state['popup_message'] = 'BBC服务异常'
                 state['need_restart'] = True  # 标记需要重启BBC
+                finished_event.set()
                 break
-            
+
             mfaalog.debug("[ExecuteBbcTask] 心跳检查正常")
-        
+
         return state['popup_title'], state['popup_message']
     

--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -470,10 +470,7 @@ class ExecuteBbcTask(CustomAction):
         if not battle_started:
             error_msg = "启动战斗失败（阵容未设置，已重试3次）"
             mfaalog.error(f"[ExecuteBbcTask] {error_msg}")
-            failure_result = {'success': False, 'error': error_msg, 'need_restart': True}
-            # Check if this failure result should short-circuit in _execute_single_battle
-            if isinstance(failure_result, dict) and not failure_result.get('success', True):
-                return failure_result  # Preserve 'need_restart' and 'error'
+            return {'success': False, 'error': error_msg, 'need_restart': True}
 
         mfaalog.info("[ExecuteBbcTask] 战斗已启动，等待结束...")
         return state

--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -156,7 +156,7 @@ class ExecuteBbcTask(CustomAction):
                 return {'success': False, 'error': '战斗启动失败'}
             
             # 步骤4: 等待战斗结束
-            popup_title, popup_message = self._wait_for_battle_end(state)
+            popup_title, popup_message = self._wait_for_battle_end(state, manager)
             
             manager.disconnect_tcp()
             
@@ -529,7 +529,7 @@ class ExecuteBbcTask(CustomAction):
         
         return False
     
-    def _wait_for_battle_end(self, state: dict):
+    def _wait_for_battle_end(self, state: dict, manager):
         """等待战斗结束 - 心跳检查和弹窗处理分离"""
         
         # 主线程：只做心跳检查

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -224,11 +224,10 @@ class BbcConnectionManager:
         """建立 TCP 连接"""
         with self._state_lock:
             if self._state['connected'] and self._tcp_sock:
-                # 测试连接是否仍然有效
+                # 测试连接是否仍然有效（发送 get_status 命令）
                 try:
-                    self._tcp_sock.settimeout(1)
-                    self._tcp_sock.send(b'\x00\x00\x00\x00')  # 空消息测试
-                    return True
+                    result = self.send_command('get_status', {}, timeout=2)
+                    return result.get('success', False)
                 except:
                     self._disconnect_tcp()
         

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -32,30 +32,44 @@ class BbcConnectionManager:
     """BBC 连接管理器 - 每次创建新实例"""
     
     def __init__(self):
-        # 先尝试关闭端口上的旧监听（如果有）
-        self._cleanup_port()
-        
+        try:
+            self._cleanup_port()
+        except Exception as e:
+            mfaalog.error(f"[BbcConnectionManager] 初始化期间清理端口失败: {e}")
+            raise RuntimeError(f"BbcConnectionManager 初始化失败: 端口清理阶段出错: {e}") from e
+
         self._tcp_sock: Optional[socket.socket] = None
         self._callback_server: Optional[socket.socket] = None
         self._callback_thread: Optional[threading.Thread] = None
-        self._message_queue = []  # 消息队列
+        self._message_queue = []
         self._queue_lock = threading.Lock()
-        self._popup_callback = None  # 弹窗回调函数
-        self._bbc_ready_event = threading.Event()  # BBC就绪事件
+        self._popup_callback = None
+        self._bbc_ready_event = threading.Event()
         self._state = {
             'connected': False,
             'callback_listening': False,
-            'bbc_process': None,  # BBC 进程对象
+            'bbc_process': None,
+            'bbc_stdout_file': None,
+            'bbc_stderr_file': None,
         }
         self._state_lock = threading.Lock()
-        
+        self._socket_lock = threading.Lock()
+
         mfaalog.info(f"[BbcConnectionManager] 创建新实例, ID: {id(self)}, Event ID: {id(self._bbc_ready_event)}")
-        
-        # 自动启动回调监听
-        self._start_permanent_listener()
+
+        if not self._start_permanent_listener():
+            mfaalog.error("[BbcConnectionManager] 启动永久监听失败")
+            raise RuntimeError("BbcConnectionManager 初始化失败: 永久监听无法启动")
     
     def _cleanup_port(self):
-        """清理端口上的旧监听（通过查找并终止占用端口的进程）"""
+        """
+        终止占用配置回调 TCP 端口的任何进程。
+
+        运行平台特定的检查（使用 Windows netstat 输出）查找绑定到 BBC_CALLBACK_PORT 的 LISTENING 状态 socket；
+        如果找到，尝试使用 taskkill 终止所属进程并记录结果。
+        如果未找到监听器则记录端口空闲。
+        检查或终止期间的任何意外错误都会被捕获并记录为警告。
+        """
         try:
             # Windows: 查找占用端口的 PID
             result = subprocess.run(
@@ -75,46 +89,86 @@ class BbcConnectionManager:
                     parts = line.strip().split()
                     if len(parts) >= 5:
                         pid = parts[-1]
-                        mfaalog.warning(f"[BbcConnectionManager] 检测到端口 {BBC_CALLBACK_PORT} 被 PID {pid} 占用，终止进程...")
+                        mfaalog.warning(f"[BbcConnectionManager] 检测到端口 {BBC_CALLBACK_PORT} 被 PID {pid} 占用，验证进程...")
                         try:
-                            subprocess.run(['taskkill', '/F', '/PID', pid], 
-                                         capture_output=True, timeout=3)
-                            mfaalog.info(f"[BbcConnectionManager] 已终止 PID {pid}")
-                            time.sleep(0.5)
+                            # Verify the process is a BBC/agent process before killing
+                            pid_int = int(pid)
+                            proc = psutil.Process(pid_int)
+                            cmdline = proc.cmdline()
+                            # Check if cmdline contains BBC or agent identifiers
+                            is_bbc_or_agent = any(
+                                'BBchannel' in arg or 'bbc' in arg.lower() or 'agent' in arg.lower()
+                                for arg in cmdline
+                            )
+                            if is_bbc_or_agent:
+                                mfaalog.warning(f"[BbcConnectionManager] PID {pid} 是BBC/agent进程，终止...")
+                                subprocess.run(['taskkill', '/F', '/PID', pid],
+                                             capture_output=True, timeout=3)
+                                mfaalog.info(f"[BbcConnectionManager] 已终止 PID {pid}")
+                                time.sleep(0.5)
+                            else:
+                                mfaalog.error(f"[BbcConnectionManager] PID {pid} 不是BBC/agent进程 (cmdline={cmdline})，不终止")
+                                raise RuntimeError(f"Port {BBC_CALLBACK_PORT} is occupied by non-BBC process PID {pid}")
+                        except psutil.NoSuchProcess:
+                            mfaalog.warning(f"[BbcConnectionManager] PID {pid} 已不存在")
                         except Exception as e:
-                            mfaalog.error(f"[BbcConnectionManager] 终止进程失败: {e}")
+                            mfaalog.error(f"[BbcConnectionManager] 验证或终止进程失败: {e}")
+                            raise
                     break
             else:
                 mfaalog.info(f"[BbcConnectionManager] 端口 {BBC_CALLBACK_PORT} 空闲")
         except Exception as e:
             mfaalog.warning(f"[BbcConnectionManager] 端口检查异常: {e}")
     
-    def _start_permanent_listener(self):
-        """启动永久回调监听（后台线程）"""
+    def _start_permanent_listener(self) -> bool:
+        """
+        启动绑定到 localhost:BBC_CALLBACK_PORT 的后台 TCP 监听器，用于接收 BBC 回调。
+
+        将内部状态 'callback_listening' 设为 True，将服务器 socket 存储在 self._callback_server 中，
+        并生成一个守护线程运行 _permanent_callback_loop 来接受和处理传入的回调连接。
+
+        返回:
+            bool: 监听器启动成功返回 True，否则返回 False。
+        """
         try:
             server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             server_sock.bind(('127.0.0.1', BBC_CALLBACK_PORT))
             server_sock.listen(5)
             server_sock.settimeout(2)
-            
+
             with self._state_lock:
                 self._callback_server = server_sock
                 self._state['callback_listening'] = True
-            
+
             self._callback_thread = threading.Thread(
                 target=self._permanent_callback_loop,
                 args=(server_sock,),
                 daemon=True
             )
             self._callback_thread.start()
-            
+
             mfaalog.info(f"[BbcConnectionManager] 永久回调监听已启动 on port {BBC_CALLBACK_PORT}")
+            return True
         except Exception as e:
             mfaalog.error(f"[BbcConnectionManager] 启动永久监听失败: {e}")
+            return False
     
     def _permanent_callback_loop(self, server_sock: socket.socket):
-        """永久回调监听主循环 - 将消息放入队列"""
+        """
+        监听 server_sock 上的长度前缀 JSON 回调消息，加入队列，并处理特殊事件。
+
+        此循环接受来自 server_sock 的连接，读取 4 字节大端长度前缀后跟 UTF-8 JSON payload，
+        将 payload 解析为 dict，追加到内部消息队列，并：
+        - 对 `popup_show` 事件调用已配置的弹窗回调（如果设置）。
+        - 收到 `server_started` 或 `disclaimer_closed` 时设置内部 BBC 就绪事件。
+
+        循环继续直到管理器的 `callback_listening` 状态变为 False。
+        Socket 超时被忽略（循环继续）；其他异常被记录且循环继续，除非监听已关闭。
+
+        参数:
+            server_sock (socket.socket): 用于接受回调连接的绑定/监听服务器 socket。
+        """
         mfaalog.info("[BbcConnectionManager] 永久回调监听循环开始")
         
         while True:
@@ -127,14 +181,12 @@ class BbcConnectionManager:
                 client_sock.settimeout(5)
                 
                 # 接收消息
-                length_bytes = self._recv_all(client_sock, 4)
-                if not length_bytes:
-                    client_sock.close()
-                    continue
-                
-                length = struct.unpack('>I', length_bytes)[0]
-                data = self._recv_all(client_sock, length)
-                if not data:
+                try:
+                    length_bytes = self._recv_all(client_sock, 4)
+                    length = struct.unpack('>I', length_bytes)[0]
+                    data = self._recv_all(client_sock, length)
+                except (ConnectionError, struct.error) as e:
+                    mfaalog.debug(f"[BbcConnectionManager] Callback receive failed: {e}")
                     client_sock.close()
                     continue
                 
@@ -187,7 +239,15 @@ class BbcConnectionManager:
         mfaalog.info("[BbcConnectionManager] 永久回调监听循环结束")
     
     def get_message(self, timeout: float = 1.0) -> Optional[dict]:
-        """从消息队列获取一条消息（阻塞等待）"""
+        """
+        从内部队列获取下一条回调消息，最多等待给定的超时时间。
+
+        参数:
+            timeout (float): 等待消息的最大秒数。
+
+        返回:
+            dict 或 None: 如果在超时前有消息可用则返回下一条消息字典，否则返回 None。
+        """
         start_time = time.time()
         while time.time() - start_time < timeout:
             with self._queue_lock:
@@ -197,62 +257,125 @@ class BbcConnectionManager:
         return None
     
     def get_messages_by_title(self, title_keyword: str, timeout: float = 2.0) -> list:
-        """获取包含指定关键词的消息列表"""
+        """
+        收集 `popup_title` 包含给定关键字的弹窗消息并返回。
+
+        参数:
+            title_keyword (str): 在每条消息的 `popup_title` 中搜索的子字符串。
+            timeout (float): 在返回前等待匹配消息的最大秒数（如果找到匹配可能更早返回）。
+
+        返回:
+            list: 匹配的消息字典列表；如果在 `timeout` 内未找到匹配则返回空列表。
+        """
         messages = []
         start_time = time.time()
-        
+
         while time.time() - start_time < timeout:
             with self._queue_lock:
                 for msg in self._message_queue[:]:
+                    # Only process popup events (skip non-popup events like server_started, disclaimer_closed)
                     popup_title = msg.get('popup_title', '')
+                    # Skip messages that are not popup events (no popup_title or event is not popup_show)
+                    if not popup_title and msg.get('event') != 'popup_show':
+                        continue
                     if title_keyword in popup_title:
                         messages.append(msg)
                         self._message_queue.remove(msg)
-            
+
             if messages:
                 break
             time.sleep(0.1)  # 缩短为0.1秒，提高响应速度
-        
+
         return messages
     
     def set_popup_callback(self, callback):
-        """设置弹窗回调函数"""
+        """
+        设置收到 BBC 弹窗事件时调用的函数。
+
+        参数:
+            callback (callable): 接受单个 dict 参数的函数——解析后的弹窗消息（例如包含 'event'、'popup_title' 等键）。
+        """
         self._popup_callback = callback
         mfaalog.info("[BbcConnectionManager] 弹窗回调已设置")
     
     def connect_tcp(self, timeout: int = 10) -> bool:
-        """建立 TCP 连接"""
+        """
+        确保管理器与 BBC 命令端口有可用的 TCP 连接。
+
+        如果管理器已标记为 connected，则验证连接是否仍然可用；否则尝试打开新的 TCP socket 到 BBC_TCP_HOST:BBC_TCP_PORT 并更新管理器的连接状态。
+
+        参数:
+            timeout (int): 用于连接和验证的 socket 级别超时秒数。
+
+        返回:
+            bool: 此调用后有可用连接返回 `true`，否则返回 `false`。
+        """
         with self._state_lock:
             if self._state['connected'] and self._tcp_sock:
-                # 测试连接是否仍然有效（发送 get_status 命令）
-                try:
-                    result = self.send_command('get_status', {}, timeout=2)
-                    return result.get('success', False)
-                except:
-                    self._disconnect_tcp()
-        
+                # 直接用 socket 探针测试连接，避免通过 send_command() 重入 _state_lock
+                if self._probe_socket():
+                    return True
+                self._disconnect_tcp()
+
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(timeout)
             sock.connect((BBC_TCP_HOST, BBC_TCP_PORT))
-            
+
             with self._state_lock:
                 self._tcp_sock = sock
                 self._state['connected'] = True
-            
+
             mfaalog.info(f"[BbcConnectionManager] TCP 连接成功 {BBC_TCP_HOST}:{BBC_TCP_PORT}")
             return True
         except Exception as e:
             mfaalog.error(f"[BbcConnectionManager] TCP 连接失败: {e}")
             return False
+
+    def _probe_socket(self) -> bool:
+        """
+        用 socket 探针直接测试现有连接是否可用，不经过 send_command()（避免重入 _state_lock）。
+
+        发送一个 get_status JSON 命令，接收响应，根据是否成功返回 True/False。
+        """
+        sock = self._tcp_sock
+        data = {'cmd': 'get_status', 'args': {}}
+        try:
+            msg = json.dumps(data, ensure_ascii=False).encode('utf-8')
+            msg_with_len = len(msg).to_bytes(4, 'big') + msg
+            sock.sendall(msg_with_len)
+
+            original_timeout = sock.gettimeout()
+            sock.settimeout(2)
+
+            length_bytes = self._recv_all(sock, 4)
+            length = struct.unpack('>I', length_bytes)[0]
+            response_data = self._recv_all(sock, length)
+
+            sock.settimeout(original_timeout)
+            result = json.loads(response_data.decode('utf-8'))
+            return result.get('success', False)
+        except Exception as e:
+            mfaalog.debug(f"[BbcConnectionManager] Socket 探针失败: {e}")
+            return False
     
     def disconnect_tcp(self):
-        """断开 TCP 连接"""
+        """
+        关闭管理器与 BBC 的 TCP 连接并更新内部连接状态。
+
+        获取管理器状态锁，关闭底层 TCP socket（如果存在），清除 socket 引用，并将连接状态标记为已断开。
+        """
         with self._state_lock:
             self._disconnect_tcp()
     
     def _disconnect_tcp(self):
-        """内部断开方法（需持有锁）"""
+        """
+        关闭并清理内部 TCP socket，将管理器标记为已断开。
+
+        此方法关闭存储的 TCP socket，将 socket 引用设为 None，并将内部 `connected` 状态设为 False。
+        关闭 socket 时发生的异常被抑制。
+        应在持有实例锁的情况下调用以避免竞争条件。
+        """
         if self._tcp_sock:
             try:
                 self._tcp_sock.close()
@@ -262,54 +385,87 @@ class BbcConnectionManager:
             self._state['connected'] = False
     
     def send_command(self, cmd: str, args: dict = None, timeout: int = 10) -> dict:
-        """发送命令并等待响应"""
+        """
+        发送命令到 BBC TCP 服务器并返回解析后的 JSON 响应。
+
+        命令及其参数被编码为 JSON payload，通过管理器已建立的 TCP socket 发送。
+        函数最多等待 `timeout` 秒来接收来自服务器的长度前缀 JSON 响应，并返回解码后的字典。
+
+        参数:
+            cmd (str): 要发送的命令名称。
+            args (dict, 可选): 命令参数；如果省略则视为空字典。
+            timeout (int): 等待响应的最大秒数。
+
+        返回:
+            dict: 服务器响应的 JSON 解码字典。出错时返回 `{'success': False, 'error': <message>}` 形式的字典。
+        """
+        # 先用 _state_lock 检查连接状态
         with self._state_lock:
             if not self._tcp_sock or not self._state['connected']:
                 return {'success': False, 'error': 'Not connected'}
             sock = self._tcp_sock
-        
-        data = {'cmd': cmd, 'args': args or {}}
-        try:
-            msg = json.dumps(data, ensure_ascii=False).encode('utf-8')
-            msg_with_len = len(msg).to_bytes(4, 'big') + msg
-            sock.sendall(msg_with_len)
-            
-            # 接收响应
-            original_timeout = sock.gettimeout()
-            sock.settimeout(timeout)
-            
-            length_bytes = self._recv_all(sock, 4)
-            if not length_bytes:
-                return {'success': False, 'error': 'Connection closed'}
-            
-            length = struct.unpack('>I', length_bytes)[0]
-            response_data = self._recv_all(sock, length)
-            if not response_data:
-                return {'success': False, 'error': 'No response data'}
-            
-            sock.settimeout(original_timeout)
-            return json.loads(response_data.decode('utf-8'))
-        except socket.timeout:
-            return {'success': False, 'error': f'Timeout (cmd={cmd})'}
-        except Exception as e:
-            mfaalog.error(f"[BbcConnectionManager] 发送命令失败: {e}")
-            return {'success': False, 'error': str(e)}
+
+        # 用独立的 _socket_lock 保护发送+接收的完整交换过程，避免多线程交织
+        with self._socket_lock:
+            data = {'cmd': cmd, 'args': args or {}}
+            try:
+                msg = json.dumps(data, ensure_ascii=False).encode('utf-8')
+                msg_with_len = len(msg).to_bytes(4, 'big') + msg
+                sock.sendall(msg_with_len)
+
+                # 接收响应
+                original_timeout = sock.gettimeout()
+                sock.settimeout(timeout)
+
+                length_bytes = self._recv_all(sock, 4)
+                length = struct.unpack('>I', length_bytes)[0]
+                response_data = self._recv_all(sock, length)
+
+                sock.settimeout(original_timeout)
+                return json.loads(response_data.decode('utf-8'))
+            except socket.timeout:
+                return {'success': False, 'error': f'Timeout (cmd={cmd})'}
+            except ConnectionError as e:
+                mfaalog.error(f"[BbcConnectionManager] 连接失败: {e}")
+                return {'success': False, 'error': str(e)}
+            except Exception as e:
+                mfaalog.error(f"[BbcConnectionManager] 发送命令失败: {e}")
+                return {'success': False, 'error': str(e)}
     
     def _recv_all(self, sock: socket.socket, n: int) -> bytes:
-        """接收指定字节数"""
+        """
+        从给定 socket 精确接收 n 字节。
+
+        参数:
+            sock (socket.socket): 要读取的已连接 socket。
+            n (int): 要读取的字节数；函数阻塞直到接收到这么多字节。
+
+        返回:
+            bytes: 长度为 `n` 的字节数据。
+
+        异常:
+            ConnectionError: socket 关闭（收到空数据包）或 recv 错误时抛出。
+        """
         data = b''
         while len(data) < n:
             try:
                 packet = sock.recv(n - len(data))
                 if not packet:
-                    return None
+                    raise ConnectionError("Socket connection closed (empty packet received)")
                 data += packet
-            except:
-                return None
+            except socket.error as e:
+                raise ConnectionError(f"Socket recv failed: {e}") from e
         return data
     
     def is_connected(self) -> bool:
-        """检查TCP连接是否有效"""
+        """
+        返回管理器的 BBC TCP 命令连接当前是否可用。
+
+        如果现有 socket 的短探测失败，管理器将关闭 socket 并将其标记为已断开。
+
+        返回:
+            bool: TCP 连接可用返回 True，否则返回 False。
+        """
         with self._state_lock:
             if not self._tcp_sock or not self._state['connected']:
                 return False
@@ -321,24 +477,27 @@ class BbcConnectionManager:
                 test_msg = json.dumps({'cmd': 'get_status', 'args': {}}).encode('utf-8')
                 msg_with_len = len(test_msg).to_bytes(4, 'big') + test_msg
                 self._tcp_sock.sendall(msg_with_len)
-                
+
                 length_bytes = self._recv_all(self._tcp_sock, 4)
-                if not length_bytes:
-                    return False
-                
                 length = struct.unpack('>I', length_bytes)[0]
                 response_data = self._recv_all(self._tcp_sock, length)
-                if not response_data:
-                    return False
-                
+
                 self._tcp_sock.settimeout(original_timeout)
                 return True
-            except:
+            except Exception:
                 self._disconnect_tcp()
                 return False
     
     def ensure_connected(self, timeout: int = 5) -> bool:
-        """确保连接有效，无效则重连"""
+        """
+        确保管理器与 BBC 有活动的 TCP 连接，必要时重连。
+
+        参数:
+            timeout (int): 尝试重连时使用的连接超时秒数。
+
+        返回:
+            bool: 此调用后连接成功返回 `True`，否则返回 `False`。
+        """
         if self.is_connected():
             mfaalog.debug("[BbcConnectionManager] 连接有效")
             return True
@@ -347,7 +506,11 @@ class BbcConnectionManager:
         return self.connect_tcp(timeout=timeout)
     
     def clear_message_queue(self):
-        """清空消息队列"""
+        """
+        清空内部队列中接收的回调消息。
+
+        此操作是线程安全的，移除所有待处理消息以便后续调用 get_message 或 get_messages_by_title 只看到新接收的消息。
+        """
         with self._queue_lock:
             self._message_queue.clear()
         mfaalog.debug("[BbcConnectionManager] 消息队列已清空")
@@ -355,7 +518,15 @@ class BbcConnectionManager:
     # ==================== BBC 进程管理 ====================
     
     def _find_bbc_process(self):
-        """查找BBC进程（私有方法）"""
+        """
+        查找命令行包含 'BBchannel.exe' 的运行中 BBC 进程。
+
+        遍历系统进程，返回命令行包含 'BBchannel.exe' 的第一个进程。
+        处理单个进程的临时访问/终止错误；意外错误被记录并返回 None。
+
+        返回:
+            psutil.Process 或 None: 找到匹配的进程对象，否则返回 `None`。
+        """
         try:
             for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
                 try:
@@ -370,15 +541,35 @@ class BbcConnectionManager:
             return None
     
     def find_bbc_process(self):
-        """查找BBC进程（公共接口）"""
+        """
+        查找命令行包含 'BBchannel.exe' 的运行中 BBC 进程。
+
+        返回:
+            psutil.Process: 找到匹配的进程对象，否则返回 `None`。
+        """
         return self._find_bbc_process()
     
     def _kill_bbc_process(self, proc=None):
-        """终止BBC进程"""
+        """
+        终止正在运行的 BBC 子进程，关闭其重定向的 stdout/stderr 文件句柄，并清除相关状态字段。
+
+        如果提供了 `proc`，则针对该进程；否则使用管理器存储的 `bbc_process`。
+        此方法将尝试优雅终止，如果在超时内进程未退出则回退到 kill，
+        关闭任何关联的 stdout/stderr 文件对象，并将管理器的 `bbc_process`、`bbc_stdout_file` 和 `bbc_stderr_file` 状态条目设为 None。
+
+        参数:
+            proc (subprocess.Popen | None): 要终止的可选子进程实例。如果为 None，则使用管理器状态中存储的进程。
+        """
         if proc is None:
             with self._state_lock:
                 proc = self._state.get('bbc_process')
-        
+                stdout_file = self._state.get('bbc_stdout_file')
+                stderr_file = self._state.get('bbc_stderr_file')
+        else:
+            with self._state_lock:
+                stdout_file = self._state.get('bbc_stdout_file')
+                stderr_file = self._state.get('bbc_stderr_file')
+
         try:
             # 检查进程是否还在运行 (subprocess.Popen 用 poll())
             if proc and proc.poll() is None:
@@ -390,13 +581,39 @@ class BbcConnectionManager:
                     proc.kill()
                     proc.wait(timeout=3)
                 mfaalog.info("[BbcConnectionManager] BBC进程已终止")
-                with self._state_lock:
-                    self._state['bbc_process'] = None
         except Exception as e:
             mfaalog.warning(f"[BbcConnectionManager] 终止进程失败: {e}")
+        finally:
+            # 关闭文件句柄
+            if stdout_file:
+                try:
+                    stdout_file.close()
+                    mfaalog.debug("[BbcConnectionManager] stdout文件已关闭")
+                except Exception as e:
+                    mfaalog.warning(f"[BbcConnectionManager] 关闭stdout文件失败: {e}")
+            if stderr_file:
+                try:
+                    stderr_file.close()
+                    mfaalog.debug("[BbcConnectionManager] stderr文件已关闭")
+                except Exception as e:
+                    mfaalog.warning(f"[BbcConnectionManager] 关闭stderr文件失败: {e}")
+            # 清理状态
+            with self._state_lock:
+                self._state['bbc_process'] = None
+                self._state['bbc_stdout_file'] = None
+                self._state['bbc_stderr_file'] = None
     
     def _launch_bbc(self):
-        """启动BBC进程"""
+        """
+        启动 BBC 可执行文件作为子进程，并将进程记录在管理器状态中。
+
+        启动 BBchannel.exe（路径由 BBC_EXE_PATH 定义），将 stdout/stderr 重定向到
+        可执行目录中的 bbc_stdout.log/bbc_stderr.log，成功时将 subprocess.Popen 对象
+        存储在 self._state['bbc_process'] 中。
+
+        返回:
+            subprocess.Popen 或 None: 启动成功返回启动的进程对象，如果可执行文件缺失或启动失败返回 `None`。
+        """
         if not os.path.exists(BBC_EXE_PATH):
             mfaalog.error(f"[BbcConnectionManager] BBC可执行文件不存在: {BBC_EXE_PATH}")
             return None
@@ -412,7 +629,7 @@ class BbcConnectionManager:
             # 重定向输出到文件
             stdout_file = open(os.path.join(bbc_dir, 'bbc_stdout.log'), 'w', encoding='utf-8')
             stderr_file = open(os.path.join(bbc_dir, 'bbc_stderr.log'), 'w', encoding='utf-8')
-            
+
             proc = subprocess.Popen(
                 [BBC_EXE_PATH],
                 cwd=bbc_dir,
@@ -421,17 +638,37 @@ class BbcConnectionManager:
                 stderr=stderr_file
             )
             mfaalog.info(f"[BbcConnectionManager] BBC进程已启动，PID: {proc.pid}")
-            
+
             with self._state_lock:
                 self._state['bbc_process'] = proc
-            
+                self._state['bbc_stdout_file'] = stdout_file
+                self._state['bbc_stderr_file'] = stderr_file
+
             return proc
         except Exception as e:
             mfaalog.error(f"[BbcConnectionManager] 启动BBC失败: {e}")
+            # 确保在失败时关闭文件句柄
+            try:
+                if 'stdout_file' in locals():
+                    stdout_file.close()
+                if 'stderr_file' in locals():
+                    stderr_file.close()
+            except:
+                pass
             return None
     
     def _wait_for_bbc_ready(self, timeout: int = 30) -> bool:
-        """等待 BBC 就绪信号"""
+        """
+        等待 BBC 就绪事件被设置。
+
+        阻塞最多 `timeout` 秒，等待指示 BBC 已就绪的内部就绪事件。
+
+        参数:
+            timeout (int): 等待就绪事件的最大秒数。
+
+        返回:
+            bool: 在 `timeout` 内就绪事件被设置则返回 `True`，否则返回 `False`。
+        """
         mfaalog.info(f"[BbcConnectionManager] 等待BBC就绪 (超时{timeout}s)...")
         ready = self._bbc_ready_event.wait(timeout=timeout)
         
@@ -445,13 +682,38 @@ class BbcConnectionManager:
     # ==================== 模拟器连接 ====================
     
     def connect_emulator(self, connect_cmd: str, connect_args: dict, timeout: int = 30) -> bool:
-        """连接模拟器（封装 BBC 命令）"""
+        """
+        尝试将 BBC 连接到模拟器并验证模拟器报告的状态。
+
+        参数:
+            connect_cmd (str): 请求模拟器连接的 BBC 命令名称。
+            connect_args (dict): 命令参数。如果 `connect_args.get('mode') == 'auto'`，则不发送命令，方法短暂等待后返回成功。
+            timeout (int): 连接命令 RPC 的超时秒数。
+
+        返回:
+            bool: 操作后模拟器报告为可用或已连接则返回 `true`，否则返回 `false`。
+        """
         try:
-            # auto模式不发送连接命令，直接等待
+            # auto模式不发送连接命令，轮询连接状态直到成功或超时
             if connect_args.get('mode') == 'auto':
-                mfaalog.info("[BbcConnectionManager] Auto模式，等待BBC自动连接...")
-                time.sleep(5)
-                return True
+                mfaalog.info("[BbcConnectionManager] Auto模式，轮询连接状态...")
+                poll_timeout = 30
+                poll_interval = 1
+                start_time = time.time()
+                while time.time() - start_time < poll_timeout:
+                    try:
+                        status_result = self.send_command('get_connection', {}, timeout=5)
+                        device_available = status_result.get('available', False)
+                        device_connected = status_result.get('connected', False)
+                        if device_available or device_connected:
+                            mfaalog.info(f"[BbcConnectionManager] Auto模式连接成功 (available={device_available}, connected={device_connected})")
+                            return True
+                        mfaalog.debug(f"[BbcConnectionManager] Auto模式轮询中 (available={device_available}, connected={device_connected})")
+                    except Exception as e:
+                        mfaalog.debug(f"[BbcConnectionManager] Auto模式轮询异常: {e}")
+                    time.sleep(poll_interval)
+                mfaalog.error(f"[BbcConnectionManager] Auto模式连接超时 ({poll_timeout}s)")
+                return False
             
             # 先等待 BBC UI 完全就绪
             mfaalog.info("[BbcConnectionManager] 等待 BBC UI 完全就绪...")
@@ -487,7 +749,21 @@ class BbcConnectionManager:
     # ==================== 完整重启流程 ====================
     
     def restart_bbc_and_connect(self, connect_cmd: str, connect_args: dict, max_retries: int = 5) -> bool:
-        """重启 BBC 并连接模拟器（完整流程）"""
+        """
+        重启 BBC 应用并使用提供的命令尝试连接模拟器。
+
+        每次尝试（最多 `max_retries` 次），管理器：清空消息队列和就绪事件，确保任何现有 BBC 进程已终止，
+        启动新的 BBC 进程，等待其就绪，建立 TCP 命令连接，然后发出模拟器连接过程。
+        如果任何步骤失败则重试直到达到 `max_retries`。
+
+        参数:
+            connect_cmd (str): 要发送给 BBC 的模拟器连接命令名称（例如 'connect_ld'、'connect_mumu'、'connect_adb' 或 'auto'）。
+            connect_args (dict): 连接命令的参数；内容取决于 `connect_cmd`（例如路径、IP、模式）。
+            max_retries (int): 放弃前的最大重启和连接尝试次数。
+
+        返回:
+            bool: BBC 重启成功且模拟器连接成功则返回 `True`，否则返回 `False`。
+        """
         mfaalog.info(f"[BbcConnectionManager] ========== 开始重启 BBC ==========")
         
         for attempt in range(1, max_retries + 1):
@@ -553,17 +829,43 @@ class BbcConnectionManager:
         return False
     
     def get_state(self) -> dict:
-        """获取连接状态"""
+        """
+        返回管理器内部状态的浅拷贝。
+
+        返回:
+            dict: 内部状态字典的浅拷贝（例如包含 'connected'、'callback_listening'、'bbc_process'）。
+        """
         with self._state_lock:
             return self._state.copy()
     
     def get_last_popup(self) -> Optional[dict]:
-        """获取最近的弹窗信息"""
+        """
+        获取存储在管理器状态中的最近一次弹窗消息。
+
+        返回:
+            dict: 最近一次弹窗消息字典，如果没有弹窗记录则返回 `None`。
+        """
         with self._state_lock:
             return self._state.get('last_popup')
     
     def check_emulator_params_match(self, connect_cmd: str, expected_args: dict, actual_params: dict) -> bool:
-        """检查模拟器参数是否匹配"""
+        """
+        判断模拟器报告的参数是否满足指定连接命令的预期参数。
+
+        执行以下检查：
+        - connect_mumu: 比较预期 'path' -> 实际 'mumu_path'、'index' -> 'emulator_index'、'pkg' -> 'pkg' 和 'app_index' -> 'app_index'。
+        - connect_ld: 比较预期 'path' -> 实际 'ld_path' 和 'index' -> 'emulator_index'。
+        - connect_adb: 比较预期 'ip' -> 实际 'ip'。
+        - auto: 如果有任何实际参数存在则认为匹配。
+
+        参数:
+            connect_cmd (str): 连接命令类型（例如 "connect_mumu"、"connect_ld"、"connect_adb"、"auto"）。
+            expected_args (dict): 连接命令的预期参数值。
+            actual_params (dict): 模拟器报告的要验证的参数。
+
+        返回:
+            bool: 给定 `connect_cmd` 的实际参数满足预期则返回 `true`，否则返回 `false`。
+        """
         try:
             if connect_cmd == 'connect_mumu':
                 # MuMu: 检查 path, index, pkg, app_index
@@ -595,7 +897,11 @@ class BbcConnectionManager:
             return False
     
     def cleanup(self):
-        """清理所有资源（不关闭永久监听）"""
+        """
+        关闭任何活动的 BBC 命令 TCP 连接，同时保留永久回调监听器。
+
+        这确保管理器的 TCP 命令 socket 已关闭，相关网络资源已释放。
+        """
         self.disconnect_tcp()
         mfaalog.info("[BbcConnectionManager] TCP连接已清理")
 
@@ -605,12 +911,24 @@ _manager_instance = None
 _manager_lock = threading.Lock()
 
 def get_manager() -> BbcConnectionManager:
-    """获取或创建 BBC 连接管理器实例（进程级单例）"""
+    """
+    获取或创建进程级 BbcConnectionManager 单例。
+
+    返回:
+        BbcConnectionManager: 此进程的缓存管理器实例。
+
+    异常:
+        RuntimeError: 如果管理器构造失败（例如端口清理或监听器启动失败）。
+    """
     global _manager_instance
     if _manager_instance is None:
         with _manager_lock:
             # Double-checked locking
             if _manager_instance is None:
-                _manager_instance = BbcConnectionManager()
+                try:
+                    _manager_instance = BbcConnectionManager()
+                except Exception as e:
+                    mfaalog.error(f"[get_manager] Failed to create BbcConnectionManager: {e}")
+                    # Do not cache a failed instance
+                    raise
     return _manager_instance
-

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -379,7 +379,7 @@ class BbcConnectionManager:
         if self._tcp_sock:
             try:
                 self._tcp_sock.close()
-            except:
+            except Exception:
                 pass
             self._tcp_sock = None
             self._state['connected'] = False
@@ -653,8 +653,8 @@ class BbcConnectionManager:
                     stdout_file.close()
                 if 'stderr_file' in locals():
                     stderr_file.close()
-            except:
-                pass
+            except Exception as cleanup_error:
+                mfaalog.debug(f"[BbcConnectionManager] 清理文件句柄时出错: {cleanup_error}")
             return None
     
     def _wait_for_bbc_ready(self, timeout: int = 30) -> bool:

--- a/agent/custom/bbc_emulator_utils.py
+++ b/agent/custom/bbc_emulator_utils.py
@@ -29,14 +29,14 @@ def get_connect_command_and_args(attach_data: dict):
     if mode == 'connect_mumu':
         connect_args = {
             'path':      attach_data.get('mumu_path', ''),
-            'index':     int(attach_data.get('mumu_index', 0)),
+            'index':     int(attach_data.get('mumu_index', 0) or 0),
             'pkg':       attach_data.get('mumu_pkg', ''),
-            'app_index': int(attach_data.get('mumu_app_index', 0)),
+            'app_index': int(attach_data.get('mumu_app_index', 0) or 0),
         }
     elif mode == 'connect_ld':
         connect_args = {
             'path':  attach_data.get('ld_path', ''),
-            'index': int(attach_data.get('ld_index', 0)),
+            'index': int(attach_data.get('ld_index', 0) or 0),
         }
     elif mode == 'connect_adb':
         connect_args = {
@@ -117,7 +117,7 @@ def kill_bbc_processes():
                 import subprocess
                 result = subprocess.run(
                     ['taskkill', '/F', '/PID', str(pid)],
-                    capture_output=True, timeout=5
+                    capture_output=True, timeout=5, check=False
                 )
                 if result.returncode == 0:
                     mfaalog.info(f"[kill_bbc] taskkill PID={pid} 成功")

--- a/agent/custom/bbc_emulator_utils.py
+++ b/agent/custom/bbc_emulator_utils.py
@@ -1,0 +1,133 @@
+"""
+BBC 模拟器工具函数 - 连接参数解析与进程强制清理
+"""
+import os
+import sys
+import time
+import psutil
+import mfaalog
+
+
+def get_connect_command_and_args(attach_data: dict):
+    """
+    根据 attach_data 中的 connect_mode 直接返回对应的命令名和参数字典。
+
+    connect_mode 支持的值（直接可用，无需映射）：
+    - 'connect_mumu' → 返回 mumu 模拟器相关参数
+    - 'connect_ld'   → 返回 LD 模拟器相关参数
+    - 'connect_adb'  → 返回 ADB 连接参数
+    - 'auto'         → 自动连接已配置的设备
+
+    Parameters:
+        attach_data (dict): 节点 attach 配置，包含 connect_mode 及对应的连接参数。
+
+    Returns:
+        tuple: (connect_cmd: str, connect_args: dict)
+    """
+    mode = attach_data.get('connect_mode', 'auto')
+
+    if mode == 'connect_mumu':
+        connect_args = {
+            'path':      attach_data.get('mumu_path', ''),
+            'index':     int(attach_data.get('mumu_index', 0)),
+            'pkg':       attach_data.get('mumu_pkg', ''),
+            'app_index': int(attach_data.get('mumu_app_index', 0)),
+        }
+    elif mode == 'connect_ld':
+        connect_args = {
+            'path':  attach_data.get('ld_path', ''),
+            'index': int(attach_data.get('ld_index', 0)),
+        }
+    elif mode == 'connect_adb':
+        connect_args = {
+            'ip': attach_data.get('adb_ip', ''),
+        }
+    else:
+        connect_args = {'mode': 'auto'}
+
+    return mode, connect_args
+
+
+def kill_bbc_processes():
+    """
+    强制清理所有 BBchannel.exe 进程，并记录每一步操作。
+
+    策略（强制清理）：
+    1. 用 psutil 扫描全部进程，找出命令行含 'BBchannel' 的目标进程。
+    2. 对每个目标先调用 terminate()（SIGTERM），等待最多 3 秒。
+    3. 若进程未退出，调用 kill()（SIGKILL / TerminateProcess）强制终止。
+    4. 等待进程彻底消失后记录结果。
+    5. 额外等待 1 秒，确保端口/文件锁释放。
+
+    Raises:
+        不抛出异常；所有错误均通过 mfaalog.error 记录。
+    """
+    mfaalog.info("[kill_bbc] 开始扫描 BBchannel 进程...")
+
+    targets = []
+    try:
+        for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
+            try:
+                cmdline = proc.info.get('cmdline') or []
+                name = proc.info.get('name') or ''
+                # 匹配进程名或命令行中含 BBchannel
+                if 'BBchannel' in name or any('BBchannel' in arg for arg in cmdline):
+                    targets.append(proc)
+                    mfaalog.info(f"[kill_bbc] 发现目标进程: PID={proc.pid}, name={name}")
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+    except Exception as e:
+        mfaalog.error(f"[kill_bbc] 扫描进程失败: {e}")
+        return
+
+    if not targets:
+        mfaalog.info("[kill_bbc] 未发现 BBchannel 进程，跳过清理")
+        return
+
+    mfaalog.info(f"[kill_bbc] 共发现 {len(targets)} 个目标进程，开始强制终止...")
+
+    for proc in targets:
+        pid = proc.pid
+        try:
+            # 第一步：尝试优雅终止
+            if proc.is_running():
+                mfaalog.info(f"[kill_bbc] terminate() PID={pid}")
+                proc.terminate()
+                try:
+                    proc.wait(timeout=3)
+                    mfaalog.info(f"[kill_bbc] PID={pid} 已正常退出")
+                    continue
+                except psutil.TimeoutExpired:
+                    mfaalog.warning(f"[kill_bbc] PID={pid} terminate 超时，改用 kill()")
+
+            # 第二步：强制 kill
+            if proc.is_running():
+                proc.kill()
+                try:
+                    proc.wait(timeout=3)
+                    mfaalog.info(f"[kill_bbc] PID={pid} 已被强制终止")
+                except psutil.TimeoutExpired:
+                    mfaalog.error(f"[kill_bbc] PID={pid} kill 后仍未退出，跳过")
+
+        except psutil.NoSuchProcess:
+            mfaalog.info(f"[kill_bbc] PID={pid} 已不存在")
+        except psutil.AccessDenied:
+            mfaalog.error(f"[kill_bbc] PID={pid} 无权限终止，尝试 taskkill...")
+            try:
+                import subprocess
+                result = subprocess.run(
+                    ['taskkill', '/F', '/PID', str(pid)],
+                    capture_output=True, timeout=5
+                )
+                if result.returncode == 0:
+                    mfaalog.info(f"[kill_bbc] taskkill PID={pid} 成功")
+                else:
+                    mfaalog.error(f"[kill_bbc] taskkill PID={pid} 失败: {result.stderr}")
+            except Exception as e2:
+                mfaalog.error(f"[kill_bbc] taskkill 异常: {e2}")
+        except Exception as e:
+            mfaalog.error(f"[kill_bbc] 终止 PID={pid} 时出错: {e}")
+
+    # 额外等待，确保系统释放文件锁和端口
+    time.sleep(1)
+    mfaalog.info("[kill_bbc] 强制清理完成")

--- a/agent/custom/bbc_start.py
+++ b/agent/custom/bbc_start.py
@@ -11,6 +11,7 @@ if _custom_dir not in sys.path:
     sys.path.insert(0, _custom_dir)
 
 from bbc_connection_manager import get_manager
+from bbc_emulator_utils import get_connect_command_and_args, kill_bbc_processes
 import mfaalog
 
 
@@ -19,6 +20,16 @@ class StartBbc(CustomAction):
     """检测BBC状态并传递参数给Manager进行启动/连接"""
 
     def run(self, context: Context, argv: CustomAction.RunArg) -> CustomAction.RunResult:
+        """
+        尝试确保 BBC 服务运行并连接到配置的模拟器；必要时重启 BBC 并重连。
+
+        参数:
+            context (Context): 动作上下文；期望节点数据包含键 "启动bbc"，其 `attach` 映射指定连接模式和模拟器参数。
+            argv (CustomAction.RunArg): 未使用的运行时参数。
+
+        返回:
+            CustomAction.RunResult: 如果模拟器已连接且参数匹配，或 BBC 重启并连接成功返回 `success=True`；失败或异常时返回 `success=False`。
+        """
         try:
             # 从 Context 获取节点数据
             node_data = context.get_node_data("启动bbc")
@@ -28,55 +39,10 @@ class StartBbc(CustomAction):
             
             attach_data = node_data.get('attach', {})
             
-            # 提取连接相关参数
-            connect = attach_data.get('connect', 'auto')
-            mumu_path = attach_data.get('mumu_path', '')
-            mumu_index = attach_data.get('mumu_index', 0)
-            mumu_pkg = attach_data.get('mumu_pkg', 'com.bilibili.fatego')
-            mumu_app_index = attach_data.get('mumu_app_index', 0)
-            ld_path = attach_data.get('ld_path', '')
-            ld_index = attach_data.get('ld_index', 0)
-            manual_port = attach_data.get('manual_port', '')
-            
-            # 将连接类型转换为 BBC 服务端命令
-            connect_cmd_map = {
-                'mumu': 'connect_mumu',
-                'ld': 'connect_ld',
-                'ldplayer': 'connect_ld', 
-                'adb': 'connect_adb',
-                'manual': 'connect_adb',
-                'connect_mumu': 'connect_mumu',
-                'connect_ld': 'connect_ld',
-                'connect_adb': 'connect_adb'
-            }
-            connect_cmd = connect_cmd_map.get(connect, connect)
-            
-            # 构建连接参数
-            connect_args = {}
-            if connect_cmd == 'connect_mumu':
-                connect_args = {
-                    'path': mumu_path,
-                    'index': int(mumu_index),
-                    'pkg': mumu_pkg,
-                    'app_index': int(mumu_app_index)
-                }
-            elif connect_cmd == 'connect_ld':
-                connect_args = {
-                    'path': ld_path,
-                    'index': int(ld_index)
-                }
-            elif connect_cmd == 'connect_adb':
-                connect_args = {
-                    'ip': manual_port
-                }
-            elif connect_cmd == 'auto':
-                connect_args = {
-                    'mode': 'auto'
-                }
-            
-            mfaalog.info(f"[StartBbc] 连接参数: connect={connect}, cmd={connect_cmd}")
-            mfaalog.info(f"[StartBbc] MuMu: path={mumu_path}, index={mumu_index}, pkg={mumu_pkg}")
-            mfaalog.info(f"[StartBbc] LD: path={ld_path}, index={ld_index}")
+            # 提取连接相关参数（使用共享helper）
+            connect_cmd, connect_args = get_connect_command_and_args(attach_data)
+
+            mfaalog.info(f"[StartBbc] 连接参数: cmd={connect_cmd}, args={connect_args}")
             
             # 步骤1: 检查BBC进程是否存在
             mfaalog.info("[StartBbc] 步骤1: 检查BBC状态...")
@@ -129,7 +95,7 @@ class StartBbc(CustomAction):
             
             # 步骤2: Kill掉所有BBC进程（清理残留窗口）
             mfaalog.info("[StartBbc] 步骤2: 清理所有BBC进程...")
-            self._kill_all_bbc_processes()
+            kill_bbc_processes()
             time.sleep(2)
             
             # 步骤3: 调用Manager的完整重启流程
@@ -146,27 +112,3 @@ class StartBbc(CustomAction):
         except Exception as e:
             mfaalog.error(f"[StartBbc] 异常: {e}")
             return CustomAction.RunResult(success=False)
-    
-    def _kill_all_bbc_processes(self):
-        """强制终止所有BBC相关进程"""
-        try:
-            import psutil
-            killed_count = 0
-            
-            for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
-                try:
-                    cmdline = proc.info.get('cmdline', [])
-                    if cmdline and any('BBchannel' in arg for arg in cmdline):
-                        mfaalog.info(f"[StartBbc] 终止进程: PID={proc.pid}, cmdline={cmdline}")
-                        proc.kill()
-                        killed_count += 1
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    continue
-            
-            if killed_count > 0:
-                mfaalog.info(f"[StartBbc] 已终止 {killed_count} 个BBC进程")
-            else:
-                mfaalog.info("[StartBbc] 未发现BBC进程")
-                
-        except Exception as e:
-            mfaalog.error(f"[StartBbc] 终止进程时异常: {e}")

--- a/agent/custom/bbc_stop.py
+++ b/agent/custom/bbc_stop.py
@@ -1,8 +1,16 @@
-import psutil
+import os
+import sys
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
 import mfaalog
+
+# 确保 custom 目录在 sys.path 中
+_custom_dir = os.path.dirname(os.path.abspath(__file__))
+if _custom_dir not in sys.path:
+    sys.path.insert(0, _custom_dir)
+
+from bbc_emulator_utils import kill_bbc_processes
 
 
 @AgentServer.custom_action("stop_bbc")
@@ -10,30 +18,16 @@ class StopBbc(CustomAction):
     """强制关闭BBC进程"""
 
     def run(self, context: Context, argv: CustomAction.RunArg) -> CustomAction.RunResult:
+        """
+        终止命令行包含 'BBchannel' 的所有运行中进程。
+
+        返回:
+            CustomAction.RunResult: 动作完成无错误返回 `success=True`，否则返回 `success=False`。
+        """
         try:
             mfaalog.info("[StopBbc] 正在终止 BBC 进程...")
-            
-            killed_count = 0
-            
-            for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
-                try:
-                    cmdline = proc.info.get('cmdline', [])
-                    if cmdline and any('BBchannel' in arg for arg in cmdline):
-                        mfaalog.info(f"[StopBbc] 找到 BBC 进程 PID: {proc.pid}")
-                        # 直接强制杀死进程（terminate无法关闭有弹窗的进程）
-                        proc.kill()
-                        killed_count += 1
-                        mfaalog.info(f"[StopBbc] 已强制杀死 BBC 进程 PID: {proc.pid}")
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    continue
-            
-            if killed_count > 0:
-                mfaalog.info(f"[StopBbc] 已终止 {killed_count} 个 BBC 进程")
-            else:
-                mfaalog.info("[StopBbc] 未找到运行中的 BBC 进程")
-            
+            kill_bbc_processes()
             return CustomAction.RunResult(success=True)
-                    
         except Exception as e:
             mfaalog.error(f"[StopBbc] 终止进程时出错: {e}")
             return CustomAction.RunResult(success=False)

--- a/agent/custom/mfaalog.py
+++ b/agent/custom/mfaalog.py
@@ -53,9 +53,16 @@ def focus(task_id):
 # ---------------------------------------------------------
 # 必须保留的设置：防止中文乱码
 # 如果 GUI 收到乱码，它可能直接丢弃整条日志，导致你看不到任何东西
+# 注意：在嵌入式或GUI环境中，sys.stdout/sys.stderr可能是自定义包装器，不支持reconfigure()
 if sys.version_info >= (3, 7):
-    sys.stdout.reconfigure(encoding='utf-8') # type: ignore
-    sys.stderr.reconfigure(encoding='utf-8') # type: ignore
+    try:
+        sys.stdout.reconfigure(encoding='utf-8')  # type: ignore
+    except AttributeError:
+        pass  # stdout不支持reconfigure()，跳过
+    try:
+        sys.stderr.reconfigure(encoding='utf-8')  # type: ignore
+    except AttributeError:
+        pass  # stderr不支持reconfigure()，跳过
 
 # ---------------------------------------------------------
 # 自测代码（直接运行这个文件测试）

--- a/agent/custom/mfaalog.py
+++ b/agent/custom/mfaalog.py
@@ -9,9 +9,13 @@ import time
 
 def _print_to_gui(prefix, msg):
     """
-    基础输出函数
-    :param prefix: 魔法前缀，如 'info:', 'error:', 'focus:'
-    :param msg: 实际消息内容
+    Write a single line to standard output using the GUI-required prefix so the MFA GUI can parse it.
+    
+    The function concatenates `prefix` and `msg` (without additional separators) and prints the result to stdout with flushing to ensure immediate delivery to GUI listeners.
+    
+    Parameters:
+        prefix (str): Prefix required by the GUI protocol (e.g., "info:", "warn:", "error:", "focus:").
+        msg (str): Message content to follow the prefix.
     """
     # 获取当前时间（可选，有些GUI会自动加时间，你可以先试带时间的，如果重复了就去掉）
     # timestamp = time.strftime("%H:%M:%S", time.localtime())
@@ -24,45 +28,69 @@ def _print_to_gui(prefix, msg):
     print(final_msg, flush=True)
 
 def info(msg):
-    """普通日志"""
+    """
+    Emit an informational log line formatted for the MFA GUI protocol.
+    
+    Parameters:
+        msg (str): Message text to send; it will be prefixed with "🟣 >>> " and sent with the protocol prefix "info:".
+    """
     # 对应开发者说的 "拼接 info:"
     _print_to_gui("info:", f"🟣 >>> {msg}")
 
 def warning(msg):
-    """警告日志"""
+    """
+    Emit a warning-level protocol line for the MFA GUI.
+    
+    The emitted line is prefixed with "warn:" and includes a visible warning marker so the GUI can recognize and display it as a warning.
+    
+    Parameters:
+        msg (str): Warning message text to emit.
+    """
     # 尝试猜测 warning 的前缀，通常是 warn: 或 warning:，如果没有就用 info: [WARN]
     _print_to_gui("warn:", f"⚠️ >>> {msg}")
 
 def error(msg):
-    """错误日志"""
+    """
+    Emit an error-level protocol line to the MFA GUI.
+    
+    Parameters:
+        msg (str): Error message to send to the GUI.
+    """
     # 尝试猜测 error 的前缀
     _print_to_gui("error:", f"🔴 >>> {msg}")
 
 def debug(msg):
-    """调试日志"""
+    """
+    Emit a debug-level log line to the MFA GUI.
+    
+    Parameters:
+        msg (str): Message text to send; passed through unchanged. The GUI may filter debug-level lines, so the message might not be displayed.
+    """
     # debug 可能会被 GUI 过滤，如果显示不出来，可以改用 info: [DEBUG]
     _print_to_gui("debug:", msg)
 
 def focus(task_id):
     """
-    特殊指令：尝试让 GUI 聚焦/高亮某个任务
-    开发者提到的 "focus" 可能指这个
+    Instructs the MFA GUI to focus or highlight a specific task.
+    
+    Parameters:
+        task_id (str): Identifier of the task to focus or highlight in the GUI.
     """
     _print_to_gui("focus:", task_id)
 
 # ---------------------------------------------------------
 # 必须保留的设置：防止中文乱码
 # 如果 GUI 收到乱码，它可能直接丢弃整条日志，导致你看不到任何东西
-# 注意：在嵌入式或GUI环境中，sys.stdout/sys.stderr可能是自定义包装器，不支持reconfigure()
+# 注意：在嵌入式或GUI环境中，sys.stdout/sys.stderr可能是自定义包装器，可能抛出各种异常，不仅仅是 AttributeError
 if sys.version_info >= (3, 7):
     try:
         sys.stdout.reconfigure(encoding='utf-8')  # type: ignore
-    except AttributeError:
-        pass  # stdout不支持reconfigure()，跳过
+    except Exception:
+        pass  # stdout 不支持 reconfigure() 或抛出其他异常，跳过
     try:
         sys.stderr.reconfigure(encoding='utf-8')  # type: ignore
-    except AttributeError:
-        pass  # stderr不支持reconfigure()，跳过
+    except Exception:
+        pass  # stderr 不支持 reconfigure() 或抛出其他异常，跳过
 
 # ---------------------------------------------------------
 # 自测代码（直接运行这个文件测试）

--- a/agent/main.py
+++ b/agent/main.py
@@ -23,6 +23,7 @@ import bbc_start
 import bbc_stop
 import sequential_tasks_action
 import general_navigation_action
+import chaldea_import_action
 
 
 def main():

--- a/agent/main.py
+++ b/agent/main.py
@@ -28,6 +28,11 @@ import chaldea_import_action
 
 def main():
     # 设置工作目录为项目根目录（兼容阿瓦隆）
+    """
+    Initialize runtime, validate CLI arguments, and run the AgentServer lifecycle.
+    
+    Sets the working directory to the project root (parent of AGENT_ROOT) if different, initializes Toolkit options, requires a `socket_id` as the last command-line argument (exits with status 1 if absent), then starts the AgentServer with that `socket_id`, waits for it to finish, and performs shutdown.
+    """
     project_root_dir = os.path.dirname(AGENT_ROOT)
     if os.getcwd() != project_root_dir:
         os.chdir(project_root_dir)

--- a/assets/options/connect_method.json
+++ b/assets/options/connect_method.json
@@ -17,7 +17,7 @@
                     }
                 },
                 {
-                    "name": "mumu",
+                    "name": "connect_mumu",
                     "label": "MuMu高速连接",
                     "option": [
                         "mumu_path",
@@ -28,13 +28,13 @@
                     "pipeline_override": {
                         "启动bbc": {
                             "attach": {
-                                "connect": "mumu"
+                                "connect": "connect_mumu"
                             }
                         }
                     }
                 },
                 {
-                    "name": "ldplayer",
+                    "name": "connect_ld",
                     "label": "雷电高速连接",
                     "option": [
                         "ld_path",
@@ -43,13 +43,13 @@
                     "pipeline_override": {
                         "启动bbc": {
                             "attach": {
-                                "connect": "ldplayer"
+                                "connect": "connect_ld"
                             }
                         }
                     }
                 },
                 {
-                    "name": "manual",
+                    "name": "connect_adb",
                     "label": "手动输入端口",
                     "option": [
                         "manual_port"
@@ -57,7 +57,7 @@
                     "pipeline_override": {
                         "启动bbc": {
                             "attach": {
-                                "connect": "manual"
+                                "connect": "connect_adb"
                             }
                         }
                     }

--- a/bbcdll/bbc_tcp_server.py
+++ b/bbcdll/bbc_tcp_server.py
@@ -50,6 +50,7 @@ Battle = None
 popup_event_queue = None
 _popup_wait_dict = {}
 _popup_wait_lock = None
+_last_resolved_popup = None
 
 # Tkinter 线程安全队列（从 TCP 线程到主线程）
 _tk_queue = None
@@ -249,7 +250,18 @@ def ensure_imports():
         return
     try:
         from consts import Consts as CT
-    except:
+    except ImportError as e:
+        _log('warning', f'[Imports] Failed to import consts.Consts: {e}, using MockCT')
+        class MockCT:
+            Gold = "gold"
+            Silver = "silver"
+            Copper = "copper"
+            Blue = "blue"
+            Colorful = "colorful"
+            BATTLE_TYPE = ['连续出击(或强化本)', '自动编队爬塔(应用操作序列设置)']
+        CT = MockCT()
+    except Exception as e:
+        _log('error', f'[Imports] Unexpected error importing consts.Consts: {e}, using MockCT')
         class MockCT:
             Gold = "gold"
             Silver = "silver"
@@ -260,12 +272,16 @@ def ensure_imports():
         CT = MockCT()
     try:
         from device import Windows, LDdevice, Mumudevice
-    except:
-        pass
+    except ImportError as e:
+        _log('warning', f'[Imports] Failed to import device modules (Windows, LDdevice, Mumudevice): {e}')
+    except Exception as e:
+        _log('error', f'[Imports] Unexpected error importing device modules: {e}')
     try:
         from FGObattle import Battle
-    except:
-        pass
+    except ImportError as e:
+        _log('warning', f'[Imports] Failed to import FGObattle.Battle: {e}')
+    except Exception as e:
+        _log('error', f'[Imports] Unexpected error importing FGObattle.Battle: {e}')
 
 # ==================== API 实现类 ====================
 
@@ -398,15 +414,15 @@ class ConnectionAPI:
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
-        import os, sys
+        import os, sys, subprocess
         if not ip:
             return {'success': False, 'error': 'IP not specified'}
         try:
             adb_path = os.path.join(os.path.dirname(sys.executable), "airtest", "core", "android", "static", "adb", "windows")
-            if not os.path.exists(os.path.join(adb_path, "adb.exe")):
+            adb_exe = os.path.join(adb_path, "adb.exe")
+            if not os.path.exists(adb_exe):
                 return {'success': False, 'error': 'ADB not found'}
-            from bbcmd import cmd
-            cmd(f'"{adb_path}/adb" connect {ip}')
+            subprocess.run([adb_exe, "connect", ip], check=False)
             from device import Android, USE_AS_BOTH
             server = page.SS.get('server', 'CH')
             device = Android(ip, server, USE_AS_BOTH, cap_method="Minicap")
@@ -418,7 +434,7 @@ class ConnectionAPI:
             def update_ui():
                 """
                 Refreshes the current BB page's tab label and its connection list to reflect the latest device and connection state.
-                
+
                 Updates the pagebar tab text for the active page and refreshes the connection list widget in the registered BB window.
                 """
                 _bb_window_global.pagebar.tags[page.idx].createText(True)
@@ -1199,6 +1215,7 @@ class ClientHandler:
         记录连接、命令、响应和错误事件。
         确保处理器退出时客户端已取消注册且 socket 已关闭。
         """
+        import json
         _log('info', f'[Client] Connected: {self.addr}')
         self.server.add_client(self)
         try:
@@ -1213,7 +1230,6 @@ class ClientHandler:
                 if not data:
                     break
                 try:
-                    import json
                     cmd = json.loads(data.decode('utf-8'))
                     _log('debug', f'[Command] {cmd.get("cmd") if isinstance(cmd, dict) else cmd}')
                     response = CommandDispatcher.dispatch(cmd)
@@ -1221,7 +1237,6 @@ class ClientHandler:
                     _log('error', f'[Command] Parse failed: {e}')
                     response = {'success': False, 'error': str(e)}
                 try:
-                    import json
                     resp_data = json.dumps(response, ensure_ascii=False).encode('utf-8')
                     self.client.sendall(len(resp_data).to_bytes(4, 'big') + resp_data)
                     resp_str = json.dumps(response, ensure_ascii=False)

--- a/bbcdll/bbc_tcp_server.py
+++ b/bbcdll/bbc_tcp_server.py
@@ -41,20 +41,38 @@ popup_event_queue = None
 _popup_wait_dict = {}
 _popup_wait_lock = None
 
+# Tkinter 线程安全队列（从 TCP 线程到主线程）
+_tk_queue = None
+_tk_root_ref = None  # Tkinter 主窗口引用，用于 after() 调用
+
 TCP_PORT = 25001
 CALLBACK_PORT = 25002
 
 # ==================== BBC 窗口注册 ====================
 
 def update_bb_window(bb_window):
-    global _bb_window_global
+    global _bb_window_global, _tk_root_ref
     _bb_window_global = bb_window
+    _tk_root_ref = bb_window  # 保存主窗口引用用于 after() 调用
     _log('info', '[Server] BBC window registered')
 
 def get_bb_page():
     if _bb_window_global is None:
         return None
     return _bb_window_global.pages[0]
+
+def _run_on_tk_thread(func):
+    """将函数分发到 Tkinter 主线程执行（线程安全）"""
+    global _tk_queue, _tk_root_ref
+    if _tk_queue is None:
+        _tk_queue = __import__('queue').Queue()
+    _tk_queue.put(func)
+    # 唤醒主线程处理队列（如果主窗口存在）
+    if _tk_root_ref is not None:
+        try:
+            _tk_root_ref.event_generate('<<TkQueueEvent>>', when='tail')
+        except Exception:
+            pass  # 主窗口可能已关闭
 
 # ==================== 弹窗机制 ====================
 
@@ -140,8 +158,11 @@ class ConnectionAPI:
             device.set_serialno(json.dumps(serialno, ensure_ascii=False))
             device.snapshot()
             page.snapshotDevice = page.operateDevice = page.device.snapshotDevice = page.device.operateDevice = device
-            _bb_window_global.pagebar.tags[page.idx].createText(True)
-            _bb_window_global.updateConnectLst(page.idx)
+            # 线程安全：将 UI 更新分发到主线程
+            def update_ui():
+                _bb_window_global.pagebar.tags[page.idx].createText(True)
+                _bb_window_global.updateConnectLst(page.idx)
+            _run_on_tk_thread(update_ui)
             _log('info', f'[Connection] MuMu connected: {emulator_name}')
             return {'success': True}
         except Exception as e:
@@ -173,8 +194,11 @@ class ConnectionAPI:
             touchDevice = Windows(device.player.bndWnd)
             page.snapshotDevice = page.device.snapshotDevice = device
             page.operateDevice = page.device.operateDevice = touchDevice
-            _bb_window_global.pagebar.tags[page.idx].createText(True)
-            _bb_window_global.updateConnectLst(page.idx)
+            # 线程安全：将 UI 更新分发到主线程
+            def update_ui():
+                _bb_window_global.pagebar.tags[page.idx].createText(True)
+                _bb_window_global.updateConnectLst(page.idx)
+            _run_on_tk_thread(update_ui)
             _log('info', f'[Connection] LD connected: index={index}')
             return {'success': True}
         except Exception as e:
@@ -202,8 +226,11 @@ class ConnectionAPI:
                 device.disconnect()
                 return {'success': False, 'error': 'ADB device unavailable'}
             page.snapshotDevice = page.operateDevice = page.device.snapshotDevice = page.device.operateDevice = device
-            _bb_window_global.pagebar.tags[page.idx].createText(True)
-            _bb_window_global.updateConnectLst(page.idx)
+            # 线程安全：将 UI 更新分发到主线程
+            def update_ui():
+                _bb_window_global.pagebar.tags[page.idx].createText(True)
+                _bb_window_global.updateConnectLst(page.idx)
+            _run_on_tk_thread(update_ui)
             _log('info', f'[Connection] ADB connected: {ip}')
             return {'success': True}
         except Exception as e:
@@ -320,11 +347,14 @@ class ConfigAPI:
         if not filename:
             return {'success': False, 'error': 'filename required'}
 
-        # BBC 工作目录是 dist/BBchannel64，settings 在 ../settings
-        # __file__ = d:\BBC\BBchannel\dist\BBchannel64\bbc_tcp_server.py
-        # 3层 dirname = d:\BBC\BBchannel
-        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        config_path = os.path.join(base_dir, "settings", filename)
+        # 路径安全检查：防止 ../ 逃逸
+        if '..' in filename or '/' in filename or '\\' in filename:
+            _log('error', f'[Config] Invalid filename (path traversal detected): {filename}')
+            return {'success': False, 'error': 'Invalid filename: path traversal not allowed'}
+
+        # BBC 进程的工作目录就是 BBchannel 根目录，直接使用相对路径
+        config_path = os.path.join("settings", filename)
+        
         if not os.path.exists(config_path):
             return {'success': False, 'error': f'Config file not found: {config_path}'}
         try:
@@ -334,10 +364,14 @@ class ConfigAPI:
             SS["snapshotDevice"] = page.SS.get("snapshotDevice", None)
             SS["operateDevice"] = page.SS.get("operateDevice", None)
             page.SS = SS
-            page.reset()
+            # 线程安全：page.reset() 可能触发 UI 重绘
+            _run_on_tk_thread(page.reset)
             _bb_window_global.saveJsons()
             _log('info', f'[Config] Loaded: {filename}')
             return {'success': True}
+        except json.JSONDecodeError as e:
+            _log('error', f'[Config] JSON parse error in {filename}: {e}')
+            return {'success': False, 'error': f'Invalid JSON format: {str(e)}'}
         except Exception as e:
             _log('error', f'[Config] Load failed: {e}')
             return {'success': False, 'error': str(e)}
@@ -350,14 +384,23 @@ class ConfigAPI:
         import os, json
         if not filename:
             return {'success': False, 'error': 'filename required'}
+        
+        # 路径安全检查：防止 ../ 逃逸
+        if '..' in filename or '/' in filename or '\\' in filename:
+            _log('error', f'[Config] Invalid filename (path traversal detected): {filename}')
+            return {'success': False, 'error': 'Invalid filename: path traversal not allowed'}
+        
+        # BBC 进程的工作目录就是 BBchannel 根目录，直接使用相对路径（与 BBchannelUI.py 一致）
+        config_path = os.path.join("settings", filename)
+        
         try:
-            config_path = os.path.join("settings", filename)
             os.makedirs(os.path.dirname(config_path), exist_ok=True)
             with open(config_path, "w", encoding="utf8") as fp:
                 json.dump(page.SS, fp, ensure_ascii=False, indent=4)
             _log('info', f'[Config] Saved: {filename}')
             return {'success': True}
         except Exception as e:
+            _log('error', f'[Config] Save failed: {e}')
             return {'success': False, 'error': str(e)}
 
     @staticmethod
@@ -397,9 +440,12 @@ class BattleSettingsAPI:
             return {'success': False, 'error': f'Unknown apple type: {apple_type}'}
         try:
             page.appleSet.appleType = CT.Gold if apple_type == "gold" else getattr(CT, apple_type.capitalize(), CT.Gold)
-            page.appleSet.appleIconPhoto = page.appleSet.getAppleIconPhoto()
-            if hasattr(page.appleSet, 'appleIcon'):
-                page.appleSet.appleIcon.config(image=page.appleSet.appleIconPhoto)
+            # 线程安全：getAppleIconPhoto() 创建 PhotoImage，config() 更新 widget
+            def update_apple_icon():
+                page.appleSet.appleIconPhoto = page.appleSet.getAppleIconPhoto()
+                if hasattr(page.appleSet, 'appleIcon'):
+                    page.appleSet.appleIcon.config(image=page.appleSet.appleIconPhoto)
+            _run_on_tk_thread(update_apple_icon)
             _log('info', f'[Battle] Apple type set: {apple_type}')
             return {'success': True, 'apple_type': apple_type}
         except Exception as e:
@@ -465,9 +511,12 @@ class BattleControlAPI:
             for i in range(3):
                 if not page.servantGroup[i].exist:
                     return {'success': False, 'error': f'Servant slot {i} is empty'}
-            btn_x = page.start.winfo_width() // 2
-            btn_y = page.start.winfo_height() // 2
-            page.start.event_generate("<Button-1>", x=btn_x, y=btn_y)
+            # 线程安全：event_generate() 必须在主线程调用
+            def click_start_button():
+                btn_x = page.start.winfo_width() // 2
+                btn_y = page.start.winfo_height() // 2
+                page.start.event_generate("<Button-1>", x=btn_x, y=btn_y)
+            _run_on_tk_thread(click_start_button)
             _log('info', '[Battle] Battle started')
             return {'success': True}
         except Exception as e:
@@ -619,13 +668,23 @@ class StatusAPI:
                 'battle_running': False
             }
         try:
-            # 获取topLabel文本
-            top_label_text = ''
-            if hasattr(page, 'topLabel'):
-                try:
-                    top_label_text = page.topLabel.cget('text')
-                except:
-                    pass
+            # 线程安全：cget() 严格意义上非线程安全，但实践中较少崩溃
+            # 为保持一致性，也通过队列执行
+            result = {'text': ''}
+            def read_top_label():
+                if hasattr(page, 'topLabel'):
+                    try:
+                        result['text'] = page.topLabel.cget('text')
+                    except:
+                        pass
+            _run_on_tk_thread(read_top_label)
+            # 等待主线程执行（短超时）
+            import time
+            for _ in range(10):
+                time.sleep(0.05)
+                if result['text'] or not hasattr(page, 'topLabel'):
+                    break
+            top_label_text = result['text']
             
             device_running = bool(getattr(page.device, 'running', False))
             

--- a/bbcdll/bbc_tcp_server.py
+++ b/bbcdll/bbc_tcp_server.py
@@ -19,6 +19,16 @@ if ENABLE_LOG and not _server_logger.handlers:
     _server_logger.addHandler(_fh)
 
 def _log(level, msg):
+    """
+    将消息记录到 stdout，并在启用时转发到模块日志器。
+
+    参数:
+        level (str): 日志级别，取值之一为 'debug'、'info'、'warning'、'error'。未知值在转发到日志器时被忽略。
+        msg (str): 要发出的消息文本。
+
+    注意:
+        总是打印以 "[BBC-TCP]" 为前缀的消息。如果 ENABLE_LOG 为 False，消息不会转发到文件日志器。
+    """
     print(f"[BBC-TCP] {msg}")
     import sys
     sys.stdout.flush()
@@ -51,18 +61,84 @@ CALLBACK_PORT = 25002
 # ==================== BBC 窗口注册 ====================
 
 def update_bb_window(bb_window):
+    """
+    注册应用的 Tkinter root/窗口供 TCP 服务器使用。
+
+    将提供的 `bb_window` 注册为模块级 BB 窗口引用和用于在 Tkinter 主线程上调度 UI 工作的 Tk root；同时初始化 Tk 队列处理器。
+
+    参数:
+        bb_window: 要注册的主 Tkinter 窗口或 root 对象。
+    """
     global _bb_window_global, _tk_root_ref
     _bb_window_global = bb_window
     _tk_root_ref = bb_window  # 保存主窗口引用用于 after() 调用
+    _setup_tk_queue_handler()
     _log('info', '[Server] BBC window registered')
 
 def get_bb_page():
+    """
+    从已注册的 BB 窗口返回主页面对象。
+
+    返回:
+        object: 存储的 BB 窗口的第一个页面对象（`_bb_window_global.pages[0]`），如果没有注册 BB 窗口则返回 `None`。
+    """
     if _bb_window_global is None:
         return None
     return _bb_window_global.pages[0]
 
+def _process_tk_queue(event=None):
+    """
+    执行并排空 Tkinter 主线程队列中排队的所有可调用对象。
+
+    如果内部 Tk 队列未初始化则为空操作。此函数重复检索并调用队列中的每个可调用对象，直到队列为空。
+    单个可调用对象引发的异常被捕获并记录；剩余项目的处理继续进行。
+
+    参数:
+        event (可选): 当此函数用作事件处理器时被忽略的 Tk 事件对象。
+    """
+    global _tk_queue
+    if _tk_queue is None:
+        return
+    # Process all queued functions (non-blocking)
+    while True:
+        try:
+            func = _tk_queue.get_nowait()
+            try:
+                func()
+            except Exception as e:
+                _log('error', f'[TkQueue] Error executing queued function: {e}')
+        except __import__('queue').Empty:
+            break
+
+
+def _setup_tk_queue_handler():
+    """
+    确保 Tkinter 队列存在并注册一个在 Tk 主循环上处理队列中可调用对象的事件处理器。
+
+    如果未注册 Tk root，则为空操作。创建模块队列（如果缺失），并尝试在注册的 Tk root 上绑定自定义 `<<TkQueueEvent>>` 事件到队列处理处理器；
+    绑定失败被记录。
+    """
+    global _tk_root_ref, _tk_queue
+    if _tk_root_ref is None:
+        return
+    if _tk_queue is None:
+        _tk_queue = __import__('queue').Queue()
+    # Bind the event handler to process queue on event
+    try:
+        _tk_root_ref.bind('<<TkQueueEvent>>', _process_tk_queue)
+        _log('info', '[TkQueue] Event handler bound to <<TkQueueEvent>>')
+    except Exception as e:
+        _log('warning', f'[TkQueue] Failed to bind event handler: {e}')
+
+
 def _run_on_tk_thread(func):
-    """将函数分发到 Tkinter 主线程执行（线程安全）"""
+    """
+    调度可调用对象到 Tkinter 主线程运行。
+
+    将 `func` 放入内部 Tk 队列，如果注册了 Tk root 窗口，则通过生成自定义 `<<TkQueueEvent>>` 触发 root 处理队列。
+    如果未注册 Tk root，则可调用对象保持排队直到提供 root。
+    触发 Tk root 时引发的异常（例如窗口已关闭）被忽略。
+    """
     global _tk_queue, _tk_root_ref
     if _tk_queue is None:
         _tk_queue = __import__('queue').Queue()
@@ -74,9 +150,53 @@ def _run_on_tk_thread(func):
         except Exception:
             pass  # 主窗口可能已关闭
 
+def _run_on_tk_thread_and_wait(func, timeout=10):
+    """
+    调度可调用对象到 Tkinter 主线程运行，并同步等待其执行完成。
+
+    适用于必须等待 UI 操作真正完成后再继续的场景（例如 load_config 中的 page.reset()）。
+
+    参数:
+        func: 要在 Tkinter 主线程上执行的可调用对象。
+        timeout (float): 等待完成的超时秒数。
+
+    返回:
+        bool: 函数在超时内执行完成返回 True，否则返回 False。
+    """
+    import threading
+    done_event = threading.Event()
+    result = [None]
+    exception = [None]
+
+    def wrapper():
+        try:
+            func()
+        except Exception as e:
+            exception[0] = e
+        finally:
+            done_event.set()
+
+    _run_on_tk_thread(wrapper)
+    if not done_event.wait(timeout=timeout):
+        _log('warning', f'[_run_on_tk_thread_and_wait] 等待超时: {func.__name__}')
+        return False
+    if exception[0]:
+        _log('error', f'[_run_on_tk_thread_and_wait] 执行异常: {exception[0]}')
+        return False
+    return True
+
 # ==================== 弹窗机制 ====================
 
 def _remove_popup_from_queue(popup_id):
+    """
+    从全局 popup_event_queue 中移除与给定 popup_id 匹配的所有弹窗事件。
+
+    如果队列为 None，则函数不执行任何操作。其他排队的弹窗事件被保留并按原始顺序重新排队。
+    此函数是非阻塞的，如果队列为空或无法检索项目不会抛出异常。
+
+    参数:
+        popup_id (str): 要移除的弹窗事件的唯一标识符。
+    """
     global popup_event_queue
     if popup_event_queue is None:
         return
@@ -92,6 +212,16 @@ def _remove_popup_from_queue(popup_id):
         popup_event_queue.put(p)
 
 def _resolve_popup(popup_id, action):
+    """
+    通过记录提供的操作并将其标记为已解决来解析跟踪的弹窗。
+
+    如果 popup_id 存在于内部等待字典中且其状态为 "waiting"，则将其 `result` 设为 `action`，`status` 设为 "resolved"，
+    并用弹窗的 `title`、`message` 和提供的 `action` 更新模块级 `_last_resolved_popup`。
+
+    参数:
+        popup_id (str): 要解析的弹窗标识符。
+        action:要与弹窗关联的解析值（例如 'ok'、'cancel'、True/False）。
+    """
     global _last_resolved_popup
     with _popup_wait_lock:
         popup_info = _popup_wait_dict.get(popup_id)
@@ -107,6 +237,13 @@ def _resolve_popup(popup_id, action):
 # ==================== 模块延迟导入 ====================
 
 def ensure_imports():
+    """
+    确保可选模块和常量作为模块级全局变量可用。
+
+    尝试从 `consts` 导入 `Consts`（赋给全局 `CT`）、从 `device` 导入 `Windows`、`LDdevice`、`Mumudevice`，
+    并从 `FGObattle` 导入 `Battle`。
+    如果 `consts.Consts` 无法导入，则用提供颜色常量和 `BATTLE_TYPE` 列表的最小 `MockCT` 填充 `CT`。
+    """
     global CT, Battle, Windows, LDdevice, Mumudevice
     if CT is not None:
         return
@@ -135,6 +272,18 @@ def ensure_imports():
 class ConnectionAPI:
     @staticmethod
     def connect_mumu(path=None, index=0, pkg=None, app_index=0):
+        """
+        连接 MuMu 模拟器实例并将其注册为 BB 客户端的当前设备。
+
+        参数:
+            path (str | None): MuMu 安装目录；如果为 None，函数将尝试从 MuMuInstallPath.txt 读取保存的路径。
+            index (int): 模拟器索引（0 表示默认实例）。
+            pkg (str | None): 在模拟器上使用的 Android 包名；省略时默认为 "com.bilibili.fatego"。
+            app_index (int): 传递给 Mumudevice 构造器的应用索引。
+
+        返回:
+            dict: 成功时返回 {'success': True}；失败时返回 {'success': False, 'error': '<message>'}。
+        """
         ensure_imports()
         page = get_bb_page()
         if page is None:
@@ -160,6 +309,11 @@ class ConnectionAPI:
             page.snapshotDevice = page.operateDevice = page.device.snapshotDevice = page.device.operateDevice = device
             # 线程安全：将 UI 更新分发到主线程
             def update_ui():
+                """
+                刷新当前 BB 页面的标签及其连接列表以反映最新的设备和连接状态。
+
+                更新活动页面的 pagebar 标签文本，并刷新已注册 BB 窗口中的连接列表 widget。
+                """
                 _bb_window_global.pagebar.tags[page.idx].createText(True)
                 _bb_window_global.updateConnectLst(page.idx)
             _run_on_tk_thread(update_ui)
@@ -171,6 +325,21 @@ class ConnectionAPI:
 
     @staticmethod
     def connect_ld(path=None, index=0):
+        """
+        连接到 LDPlayer 安装，将生成的设备附加到当前 BB 页面，并调度 UI 刷新。
+
+        参数:
+            path (str | None): LDPlayer 安装路径。如果省略，尝试从 "LDInstallPath.txt" 读取上次使用的路径。
+            index (int): 用于标识实例并填充设备序列信息的模拟器索引。
+
+        返回:
+            dict: 成功时返回 {'success': True}；失败时返回 {'success': False, 'error': <message>}。
+
+        注意:
+            - 成功时验证的路径会持久化到 "LDInstallPath.txt"。
+            - 创建的 LDdevice 被分配给页面的 snapshotDevice/operateDevice 槽，Windows touch wrapper 被分配给 operateDevice。
+            - 在 Tkinter 主线程上调度 UI 更新以刷新页面标签和连接列表。
+        """
         ensure_imports()
         page = get_bb_page()
         if page is None:
@@ -196,6 +365,11 @@ class ConnectionAPI:
             page.operateDevice = page.device.operateDevice = touchDevice
             # 线程安全：将 UI 更新分发到主线程
             def update_ui():
+                """
+                Refreshes the current BB page's tab label and its connection list to reflect the latest device and connection state.
+                
+                Updates the pagebar tab text for the active page and refreshes the connection list widget in the registered BB window.
+                """
                 _bb_window_global.pagebar.tags[page.idx].createText(True)
                 _bb_window_global.updateConnectLst(page.idx)
             _run_on_tk_thread(update_ui)
@@ -207,6 +381,19 @@ class ConnectionAPI:
 
     @staticmethod
     def connect_adb(ip):
+        """
+        通过 ADB 连接到 Android 设备并将其注册为当前页面设备。
+
+        验证本地 adb 可执行文件是否存在，运行 `adb connect {ip}`，创建 Android 设备实例并将其分配给页面的 snapshot/operate 设备字段，
+        并调度 Tkinter 线程 UI 刷新以反映新连接。
+
+        参数:
+            ip (str): 要通过 ADB 连接的 Android 设备的 IP 地址（host[:port]）。
+
+        返回:
+            dict: 成功时返回 `{'success': True}`。
+                  失败时返回 `{'success': False, 'error': <message>}`（例如 BBC 窗口未就绪、缺少 `ip`、ADB 未找到、设备不可用或其他连接错误）。
+        """
         ensure_imports()
         page = get_bb_page()
         if page is None:
@@ -221,13 +408,19 @@ class ConnectionAPI:
             from bbcmd import cmd
             cmd(f'"{adb_path}/adb" connect {ip}')
             from device import Android, USE_AS_BOTH
-            device = Android(ip, page.server, USE_AS_BOTH, cap_method="Minicap")
+            server = page.SS.get('server', 'CH')
+            device = Android(ip, server, USE_AS_BOTH, cap_method="Minicap")
             if not device.available:
                 device.disconnect()
                 return {'success': False, 'error': 'ADB device unavailable'}
             page.snapshotDevice = page.operateDevice = page.device.snapshotDevice = page.device.operateDevice = device
             # 线程安全：将 UI 更新分发到主线程
             def update_ui():
+                """
+                Refreshes the current BB page's tab label and its connection list to reflect the latest device and connection state.
+                
+                Updates the pagebar tab text for the active page and refreshes the connection list widget in the registered BB window.
+                """
                 _bb_window_global.pagebar.tags[page.idx].createText(True)
                 _bb_window_global.updateConnectLst(page.idx)
             _run_on_tk_thread(update_ui)
@@ -239,6 +432,14 @@ class ConnectionAPI:
 
     @staticmethod
     def disconnect():
+        """
+        停止并断开 BB 窗口当前注册的设备。
+
+        尝试将设备标记为不运行，如果设备有 `disconnect()` 方法则调用它。
+
+        返回:
+            dict: 成功停止/断开时返回 `{'success': True}`，或者如果 BB 窗口未就绪或发生错误则返回 `{'success': False, 'error': <message>}`。
+        """
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
@@ -253,6 +454,27 @@ class ConnectionAPI:
 
     @staticmethod
     def get_connection():
+        """
+        从已注册的 BB 窗口获取当前设备连接和运行时元数据。
+
+        返回:
+            dict: 包含以下键的字典：
+                - connected (bool): 设备是否已连接/可用。
+                - available (bool): 与 `connected` 相同。
+                - running (bool): 设备/任务是否正在运行。
+                - task_name (str): 设备的当前任务名称。
+                - device_type (str): 设备对象的运行时类名（错误时为 'Unknown'）。
+                - device_info (dict): 详细设备信息，包含：
+                    - serialno (str): 设备序列字符串。
+                    - running (bool): 与顶层 `running` 相同。
+                    - task_name (str): 与顶层 `task_name` 相同。
+                    - emulator_params (dict): 尽力而为的模拟器特定参数：
+                        - Mumudevice: `mumu_path`、`emulator_index`、`app_index`、`pkg`。
+                        - LDdevice: `ld_path`、`emulator_index`。
+                        - Android/ADB: `ip`（如果可能从 serial 解析）。
+                    - player_hwnd (str, 可选): 播放器窗口句柄（如果有）。
+                - error (str, 可选): 检索失败时的错误信息。
+        """
         page = get_bb_page()
         if page is None:
             return {
@@ -340,6 +562,18 @@ class ConnectionAPI:
 class ConfigAPI:
     @staticmethod
     def load_config(filename):
+        """
+        从设置目录加载配置 JSON 并应用到已注册 BB 窗口状态。
+
+        替换页面设置时保留当前页面的 `connectMode`、`snapshotDevice` 和 `operateDevice` 键，
+        在 Tkinter 线程上调度 UI 重置，并通过全局 BB 窗口保存程序持久化设置。
+
+        参数:
+            filename (str): 位于 `settings` 目录下的配置文件基本名。不得包含路径遍历序列（`..`、`/` 或 `\`）。
+
+        返回:
+            dict: 操作结果。成功时：`{'success': True}`。失败时：`{'success': False, 'error': <message>}` 描述原因（例如文件未找到、无效 JSON、BBC 窗口未就绪）。
+        """
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
@@ -364,8 +598,9 @@ class ConfigAPI:
             SS["snapshotDevice"] = page.SS.get("snapshotDevice", None)
             SS["operateDevice"] = page.SS.get("operateDevice", None)
             page.SS = SS
-            # 线程安全：page.reset() 可能触发 UI 重绘
-            _run_on_tk_thread(page.reset)
+            # 线程安全：page.reset() 必须真正完成后再返回，否则后续的 set_apple_type 等会覆盖刚加载的值
+            if not _run_on_tk_thread_and_wait(page.reset, timeout=10):
+                return {'success': False, 'error': 'page.reset() 执行超时'}
             _bb_window_global.saveJsons()
             _log('info', f'[Config] Loaded: {filename}')
             return {'success': True}
@@ -378,6 +613,15 @@ class ConfigAPI:
 
     @staticmethod
     def save_config(filename):
+        """
+        将当前 BB 频道配置保存到 settings 目录下的文件中。
+
+        参数:
+            filename (str): 要写入 "settings" 目录内的文件名。必须是简单文件名（不能包含 ".."、"." 或 "\" 以防止路径遍历）。
+
+        返回:
+            dict: 成功时返回 `{'success': True}`；失败时返回 `{'success': False, 'error': <message>}` 描述问题。
+        """
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
@@ -405,6 +649,12 @@ class ConfigAPI:
 
     @staticmethod
     def get_config():
+        """
+        获取当前加载的 BB 窗口配置。
+
+        返回:
+            dict: 如果 BB 窗口已就绪，返回 `{'success': True, 'config': page.SS}`，其中 `config` 是设置字典；否则返回 `{'success': False, 'error': <message>}`。
+        """
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
@@ -427,11 +677,25 @@ class BattleSettingsAPI:
         "continuous": 0,
         "tower": 1,
         "连续出击": 0,
-        "自动编队爬塔": 1
+        "自动编队爬塔": 1,
+        "连续出击(或强化本)": 0,
+        "自动编队爬塔(应用操作序列设置)": 1,
     }
 
     @staticmethod
     def set_apple_type(apple_type):
+        """
+        设置战斗自动化的苹果类型并更新 UI 图标。
+
+        参数:
+            apple_type (str): BattleSettingsAPI.APPLE_MAP 的键（例如 "gold"、"silver"、"blue"、"copper"、"colorful"）。
+
+        返回:
+            dict: 成功时返回 `{'success': True, 'apple_type': <apple_type>}`。
+                  如果 BBC 窗口未注册：`{'success': False, 'error': 'BBC window not ready'}`。
+                  如果 `apple_type` 未知：`{'success': False, 'error': 'Unknown apple type: <apple_type>'}`。
+                  如果苹果类型已应用但 UI 更新失败：`{'success': True, 'apple_type': <apple_type>, 'warning': <error message>}`。
+        """
         ensure_imports()
         page = get_bb_page()
         if page is None:
@@ -442,6 +706,11 @@ class BattleSettingsAPI:
             page.appleSet.appleType = CT.Gold if apple_type == "gold" else getattr(CT, apple_type.capitalize(), CT.Gold)
             # 线程安全：getAppleIconPhoto() 创建 PhotoImage，config() 更新 widget
             def update_apple_icon():
+                """
+                Refresh the apple icon PhotoImage on the page and update the widget if present.
+                
+                Updates page.appleSet.appleIconPhoto by calling getAppleIconPhoto(). If page.appleSet.appleIcon exists, applies the new PhotoImage to that widget.
+                """
                 page.appleSet.appleIconPhoto = page.appleSet.getAppleIconPhoto()
                 if hasattr(page.appleSet, 'appleIcon'):
                     page.appleSet.appleIcon.config(image=page.appleSet.appleIconPhoto)
@@ -454,6 +723,15 @@ class BattleSettingsAPI:
 
     @staticmethod
     def set_run_times(times):
+        """
+        设置 BB 窗口苹果设置的战斗迭代次数。
+
+        参数:
+            times (int): 期望的运行次数；必须是大于或等于 0 的整数。
+
+        返回:
+            dict: 成功时返回 `{'success': True, 'times': <int>}`。失败时返回 `{'success': False, 'error': <str>}` 描述未应用值的原因（例如 BB 窗口未就绪、无效值或内部错误）。
+        """
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
@@ -468,6 +746,15 @@ class BattleSettingsAPI:
 
     @staticmethod
     def set_battle_type(battle_type):
+        """
+        在已注册 BB 窗口的设置中设置战斗类型。
+
+        参数:
+            battle_type (str): 标识所需战斗模式的键（必须存在于 BattleSettingsAPI.BATTLE_TYPE_MAP 中）。
+
+        返回:
+            dict: 成功时返回 `{'success': True, 'battle_type': <battle_type>}`；失败时返回 `{'success': False, 'error': '<message>'}`。
+        """
         ensure_imports()
         page = get_bb_page()
         if page is None:
@@ -484,6 +771,13 @@ class BattleSettingsAPI:
 
     @staticmethod
     def get_settings():
+        """
+        从已注册 BB 窗口返回当前战斗设置。
+
+        返回:
+            dict: 成功时返回 `{'success': True, 'apple_type': <CT color constant>, 'run_times': <int>, 'battle_type': <str>}`。
+                  失败时返回 `{'success': False, 'error': <error message>}`（当 BB 窗口未就绪时也返回）。
+        """
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
@@ -501,6 +795,14 @@ class BattleSettingsAPI:
 class BattleControlAPI:
     @staticmethod
     def start_battle():
+        """
+        通过程序点击 UI 启动按钮来发起战斗。
+
+        验证 BB 窗口和 Battle 模块可用且所有三个从者槽都已填充；在 Tkinter 主线程上调度点击启动按钮。
+
+        返回:
+            dict: 成功时返回 `{'success': True}`，或者当服务器、战斗模块或从者验证失败或发生异常时返回 `{'success': False, 'error': <message>}`。
+        """
         ensure_imports()
         page = get_bb_page()
         if page is None:
@@ -513,6 +815,14 @@ class BattleControlAPI:
                     return {'success': False, 'error': f'Servant slot {i} is empty'}
             # 线程安全：event_generate() 必须在主线程调用
             def click_start_button():
+                """
+                模拟鼠标点击全局 BB 页面启动按钮中心。
+
+                在生成点击前设置 page.firstRun = False 以绕过首次运行助手设置对话框（否则会阻止自动化执行）。
+                需要全局 BB 页面及其 `start` widget 存在；入队按钮按下事件到 widget 中心。
+                """
+                # 跳过首次运行向导，避免弹出助战设置确认窗口
+                page.firstRun = False
                 btn_x = page.start.winfo_width() // 2
                 btn_y = page.start.winfo_height() // 2
                 page.start.event_generate("<Button-1>", x=btn_x, y=btn_y)
@@ -525,6 +835,14 @@ class BattleControlAPI:
 
     @staticmethod
     def stop_battle():
+        """
+        停止已注册 BB 窗口上当前运行的战斗。
+
+        如果有带运行设备的 BB 窗口可用，调用设备的 stop 操作。完成时返回成功字典，或 BBC 窗口未注册或发生异常时返回错误字典。
+
+        返回:
+            dict: 成功时返回 `{'success': True}`；如果 BBC 窗口未就绪或发生错误则返回 `{'success': False, 'error': <message>}`。
+        """
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
@@ -538,6 +856,14 @@ class BattleControlAPI:
 
     @staticmethod
     def pause_battle():
+        """
+        请求暂停当前运行的战斗（暂停未实现）。
+
+        返回:
+            dict: 包含 `success` 设为 False 和 `error` 消息的字典：
+                - 如果 BBC 窗口未注册，返回 `'BBC window not ready'`。
+                - 否则返回 `'Pause not implemented'`。
+        """
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
@@ -545,6 +871,15 @@ class BattleControlAPI:
 
     @staticmethod
     def resume_battle():
+        """
+        恢复之前暂停的战斗。
+
+        如果 BB 窗口未注册，返回指示窗口未就绪的错误。如果恢复未实现，返回明确未实现的错误。
+
+        返回:
+            dict: 当 BB 窗口未注册时返回 `{'success': False, 'error': 'BBC window not ready'}`，
+                  当恢复功能不可用时返回 `{'success': False, 'error': 'Resume not implemented'}`。
+        """
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
@@ -554,6 +889,26 @@ class BattleControlAPI:
 class StatusAPI:
     @staticmethod
     def get_status():
+        """
+        收集已注册 BB 窗口的当前 UI 和设备状态。
+
+        返回:
+            dict: 包含以下键的状态字典：
+                - 'success' (bool): 正常状态响应为 True。
+                - 'ready' (bool): BB 页面已注册且状态已收集时为 True，否则为 False。
+                - 'device_available' (bool): 当前设备是否标记为可用。
+                - 'device_running' (bool): 设备当前是否正在运行。
+                - 'task_name' (str): 当前设备任务名称（如果没有则为空字符串）。
+                - 'device_type' (str): 设备运行时类名；当没有页面注册时为 'None'。
+                - 'device_info' (dict): 设备详细信息，包含：
+                    - 'serialno' (str): 设备序列标识符。
+                    - 'running' (bool): 反映 'device_running'。
+                    - 'task_name' (str): 反映 'task_name'。
+                    - 'player_hwnd' (str, 可选): 设备播放器窗口句柄（如果有）。
+                - 'battle_settings' (dict): 尽力而为的战斗 UI 设置；可能包含 'apple_type' (str)、'run_times' (int) 和 'battle_type' (str)。
+                - 'popup_queue_size' (int): 待处理弹窗事件数量（如果弹窗队列未初始化则为 0）。
+                - 'error' (str, 可选): 当 'ready' 为 False 且由于异常时存在；包含错误信息。
+        """
         page = get_bb_page()
         if page is None:
             return {
@@ -612,6 +967,14 @@ class StatusAPI:
 
     @staticmethod
     def get_popups():
+        """
+        获取跟踪的弹窗事件摘要而不修改内部弹窗队列。
+
+        扫描模块弹窗事件队列，收集其 `id` 在 popup-wait 字典中的条目，然后恢复队列到原始内容。
+
+        返回:
+            dict: `{'success': True, 'popups': [...]}`，其中 `popups` 是对象列表，每个包含 `id`、`title`、`message` 和 `type`（默认为 `'unknown'`）。
+        """
         if popup_event_queue is None:
             return {'success': True, 'popups': []}
         popups = []
@@ -637,6 +1000,16 @@ class StatusAPI:
 
     @staticmethod
     def popup_response(popup_id, action):
+        """
+        记录弹窗的响应并将其标记为已解决。
+
+        参数:
+            popup_id (str|int): 要解析的弹窗标识符。
+            action (str): 为弹窗选择的操作（例如 "ok"、"cancel"、"yes"、"no"）。
+
+        返回:
+            dict: 找到弹窗并标记为已解决时返回 `{'success': True}`，否则返回 `{'success': False, 'error': 'Popup not found or already resolved'}`。
+        """
         with _popup_wait_lock:
             popup_info = _popup_wait_dict.get(popup_id)
             if popup_info and popup_info.get('status') == 'waiting':
@@ -648,6 +1021,15 @@ class StatusAPI:
 
     @staticmethod
     def wait_for_popup(timeout=30):
+        """
+        阻塞直到弹窗出现在内部弹窗事件队列中或超时。
+
+        参数:
+            timeout (int | float): 等待弹窗的最大秒数。
+
+        返回:
+            dict: 在超时前检测到弹窗则返回 `{'success': True, 'has_popup': True}`，否则返回 `{'success': True, 'has_popup': False}`。
+        """
         import time
         start = time.time()
         while time.time() - start < timeout:
@@ -658,7 +1040,19 @@ class StatusAPI:
 
     @staticmethod
     def get_ui_status():
-        """获取UI状态信息（包括topLabel提示文本）"""
+        """
+        获取当前 UI 状态和运行标志；在 Tkinter 主线程上读取顶部标签文本。
+
+        通过 Tk 线程（如果有）读取窗口顶部标签文本，并报告设备和战斗运行状态。
+
+        返回:
+            dict: 包含以下键的字典：
+                - 'success' (bool): 状态被收集时为 `True`（仅对意外失败才为 `False`）。
+                - 'top_label' (str): UI 顶部标签的当前文本（如果不可用则为空字符串）。
+                - 'device_running' (bool): 设备当前是否正在运行。
+                - 'battle_running' (bool): 战斗是否正在运行（在此上下文中与 `device_running` 相同）。
+                - 'error' (str, 可选): 仅在发生异常时存在。
+        """
         page = get_bb_page()
         if page is None:
             return {
@@ -668,26 +1062,31 @@ class StatusAPI:
                 'battle_running': False
             }
         try:
-            # 线程安全：cget() 严格意义上非线程安全，但实践中较少崩溃
-            # 为保持一致性，也通过队列执行
+            # 使用 Event 同步主线程执行
+            import threading
             result = {'text': ''}
+            event = threading.Event()
+
             def read_top_label():
+                """
+                Set result['text'] to the current text of the page top label and signal completion.
+                
+                If a `page.topLabel` widget exists, attempts to read its `'text'` option into `result['text']`. If the widget is missing or an error occurs while reading, `result` is left unchanged. Always calls `event.set()` to signal completion.
+                """
                 if hasattr(page, 'topLabel'):
                     try:
                         result['text'] = page.topLabel.cget('text')
                     except:
                         pass
+                event.set()
+
             _run_on_tk_thread(read_top_label)
-            # 等待主线程执行（短超时）
-            import time
-            for _ in range(10):
-                time.sleep(0.05)
-                if result['text'] or not hasattr(page, 'topLabel'):
-                    break
+            # 等待主线程执行完成（超时0.5秒）
+            event.wait(timeout=0.5)
             top_label_text = result['text']
-            
+
             device_running = bool(getattr(page.device, 'running', False))
-            
+
             return {
                 'success': True,
                 'top_label': top_label_text,
@@ -733,6 +1132,19 @@ class CommandDispatcher:
 
     @classmethod
     def dispatch(cls, cmd):
+        """
+        将封装的命令分发给注册的处理器并返回处理器结果。
+
+        接受命令字典（或包含字典的单元素列表）。提取 'cmd' 作为处理器名称，'args' 作为关键字参数。
+        如果命名的处理器已注册，当其签名没有参数时以无参数调用，否则以提供的 `args` 调用。
+        对于无效格式、未知命令或处理器异常返回标准化错误字典。
+
+        参数:
+            cmd (dict | list): 要分发的命令。期望形状：`{'cmd': <handler_name>, 'args': { ... }}`。也接受包含此类字典的单元素列表。
+
+        返回:
+            dict: 成功时返回处理器的返回映射，失败时返回 `{'success': False, 'error': <message>}`。
+        """
         if isinstance(cmd, list):
             cmd = cmd[0] if cmd else {}
         if not isinstance(cmd, dict):
@@ -761,12 +1173,32 @@ class CommandDispatcher:
 
 class ClientHandler:
     def __init__(self, client_socket, addr, server):
+        """
+        使用底层 socket、远程地址和所属服务器初始化 ClientHandler。
+
+        参数:
+            client_socket (socket.socket): 用于帧式 JSON I/O 的已连接客户端 socket。
+            addr (tuple): socket.accept() 返回的远程地址元组，通常为 (host, port)。
+            server (BBCServer): 用于客户端注册和协调的所属服务器实例。
+
+        副作用:
+            设置实例属性 `client`、`addr`、`server`，并启用 `running` 标志。
+        """
         self.client = client_socket
         self.addr = addr
         self.server = server
         self.running = True
 
     def handle(self):
+        """
+        处理单个客户端连接：读取 4 字节大端长度前缀的 JSON 命令，分发它们，并发送长度前缀的 JSON 响应。
+
+        读取帧，其中前 4 字节编码 payload 长度（大端），后跟 UTF-8 JSON payload。
+        验证长度（必须 >0 且 <= 65535），解析 JSON 命令，通过命令分发器分发，并将分发结果作为帧式 UTF-8 JSON 响应返回。
+        JSON 解析或分发错误时，客户端收到错误响应。
+        记录连接、命令、响应和错误事件。
+        确保处理器退出时客户端已取消注册且 socket 已关闭。
+        """
         _log('info', f'[Client] Connected: {self.addr}')
         self.server.add_client(self)
         try:
@@ -807,6 +1239,15 @@ class ClientHandler:
             _log('info', f'[Client] Disconnected: {self.addr}')
 
     def _recv_exact(self, n):
+        """
+        从客户端 socket 精确读取 n 字节。
+
+        参数:
+            n (int): 要读取的字节数。
+
+        返回:
+            bytes: 长度为 `n` 的字节对象，包含接收到的数据；如果对端在读取 `n` 字节前关闭连接则返回 `b''`。
+        """
         data = b''
         while len(data) < n:
             chunk = self.client.recv(n - len(data))
@@ -816,11 +1257,29 @@ class ClientHandler:
         return data
 
     def stop(self):
+        """
+        信号处理器停止处理并终止其运行循环。
+
+        这将内部 running 标志设为 False，以便处理器的活动循环可以观察变化并退出。
+        """
         self.running = False
 
 
 class BBCServer:
     def __init__(self, port=25001):
+        """
+        创建配置为监听给定本地 TCP 端口的 BBCServer 并准备内部客户端状态。
+
+        参数:
+            port (int): 服务器绑定的 TCP 端口（默认：25001）。
+
+        初始化的属性:
+            port: 配置的监听端口。
+            socket: 服务器监听 socket（直到 start() 前为 None）。
+            running: 指示服务器循环是否活动的布尔标志。
+            clients: 已连接 ClientHandler 实例列表。
+            clients_lock: 保护 `clients` 访问的 threading.Lock。
+        """
         self.port = port
         self.socket = None
         self.running = False
@@ -828,15 +1287,40 @@ class BBCServer:
         self.clients_lock = __import__('threading').Lock()
 
     def add_client(self, client):
+        """
+        将已连接客户端注册到服务器。
+
+        通过获取服务器的 clients 锁以线程安全的方式将 `client` 添加到服务器内部客户端列表。
+
+        参数:
+            client: 要注册的客户端处理器实例。
+        """
         with self.clients_lock:
             self.clients.append(client)
 
     def remove_client(self, client):
+        """
+        如果客户端当前在列表中则将其从服务器的跟踪客户端列表中移除。
+
+        参数:
+            client: 要从服务器 clients 中移除的 ClientHandler 实例（或客户端标识符）。
+        """
         with self.clients_lock:
             if client in self.clients:
                 self.clients.remove(client)
 
     def start(self):
+        """
+        启动绑定到 127.0.0.1 实例配置端口的 TCP 服务器并接受传入的客户端连接。
+
+        设置监听 socket（SO_REUSEADDR）绑定到回环接口，标记服务器为运行中，记录启动，然后进入接受连接的循环。
+        对于每个接受的客户端，创建一个 ClientHandler 并在守护线程中运行。
+        当服务器运行时，接受错误时记录错误并退出循环。
+
+        副作用:
+            - 将 `self.socket` 分配给创建的监听 socket
+            - 设置 `self.running = True`
+        """
         import socket
         import threading
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -857,6 +1341,11 @@ class BBCServer:
                 break
 
     def stop(self):
+        """
+        停止服务器并关闭其监听 socket。
+
+        将服务器的 running 标志设为 False 并关闭监听 socket（如果存在）；socket 关闭错误被忽略。
+        """
         self.running = False
         if self.socket:
             try:
@@ -870,6 +1359,17 @@ class BBCServer:
 _tcp_server_instance = None
 
 def start_tcp_server(bb_window, port=25001):
+    """
+    注册 Tkinter BB 窗口用于远程控制，拦截受控 messagebox，并启动本地 TCP 服务器。
+
+    将模块全局变量设置为引用提供的 BB Tk 窗口，用将"受控"弹窗加入队列并协调外部解决的包装器替换六个 tkinter.messagebox 函数，
+    并启动绑定到 127.0.0.1:port 的后台 TCP 服务器。
+    此函数执行就地副作用，并为服务器和可选的回调通知生成守护线程。
+
+    参数:
+        bb_window: 要注册用于 UI 调度和弹窗拦截的主 BB 应用程序 Tkinter 窗口（Tk 或 Toplevel）。
+        port (int): 要监听的 TCP 端口（默认 25001）。
+    """
     import threading
     import queue
     from tkinter import messagebox
@@ -880,7 +1380,8 @@ def start_tcp_server(bb_window, port=25001):
     global _popup_wait_dict
     global _tcp_server_instance
 
-    _bb_window_global = bb_window
+    # Register BB window and set up Tk queue handler before any UI operations
+    update_bb_window(bb_window)
     popup_event_queue = queue.Queue()
     _popup_wait_lock = threading.Lock()
 
@@ -905,6 +1406,19 @@ def start_tcp_server(bb_window, port=25001):
     }
 
     def fix_encoding(s):
+        """
+        使用 UTF-8（带 GBK 回退）将输入值规范化为 Unicode 字符串。
+
+        如果 `s` 是 `bytes`，则使用替换字符解码为 UTF-8。
+        如果 `s` 是 `str`，则重新编码为 Latin-1 并解码为 GBK 以恢复可能误解码的字符。
+        失败时返回原始输入不变。
+
+        参数:
+            s (bytes | str | any): 要规范化的值。
+
+        返回:
+            str: 解码成功时返回解码后的 Unicode 字符串；否则返回原始输入。
+        """
         if isinstance(s, bytes):
             return s.decode('utf-8', errors='replace')
         try:
@@ -913,7 +1427,36 @@ def start_tcp_server(bb_window, port=25001):
             return s
 
     def create_popup_wrapper(func_name, original_func):
+        """
+        创建拦截和管理"受控"弹窗的 messagebox 包装器。
+
+        当对话框标题包含 CONTROLLED_POPUPS 中的任何关键字时，包装器：
+        - 在 _popup_wait_dict 中注册弹窗并在 popup_event_queue 中加入弹窗事件，
+        - 可选地向本地 CALLBACK_PORT 发送 `popup_show` 事件通知，
+        - 可自动解决特定对话框（例如免责声明或单按钮警报），
+        - 将显示和受控关闭行为委托给 _create_controlled_dialog 并返回其结果。
+
+        参数:
+            func_name (str): 被包装的 messagebox 函数名称（例如 'showinfo'、'askyesno'）。
+            original_func (callable): 对于非受控对话框调用原始 tkinter.messagebox 函数，并用于显示受控对话框。
+
+        返回:
+            callable: 具有签名 (title, message, **kwargs) 的包装函数，它调用原始 messagebox 或管理和返回受控弹窗的结果。
+        """
         def wrapper(title, message, **kwargs):
+            """
+            拦截标题包含任何配置受控关键字的 tkinter.messagebox 调用，并将其路由到模块的弹窗控制系统。
+
+            当标题不匹配受控关键字时，直接委托给原始 messagebox 函数。
+            对于受控弹窗，此函数：
+            - 注册弹窗条目并入队供外部消费者使用的弹窗事件，
+            - 可选地通知本地回调端口弹窗已显示（除非标题包含"免责声明"），
+            - 为免责声明和单按钮对话框调度自动解决，
+            - 然后显示原始对话框，而后台监视器等待外部解决。
+
+            返回:
+                底层 messagebox 调用返回的值；对于确认对话框（`ask*`/`askokcancel`/`askyesno`/`askretrycancel`）这将是 True 或 False，对于其他对话框则是被包装函数返回的内容。
+            """
             is_controlled = any(keyword in title for keyword in CONTROLLED_POPUPS)
             if not is_controlled:
                 return original_func(title, message, **kwargs)
@@ -939,6 +1482,13 @@ def start_tcp_server(bb_window, port=25001):
             # 非免责声明的弹窗立即推送通知（免责声明会自动关闭，走popup_closed流程）
             if CALLBACK_PORT and '免责声明' not in title:
                 def send_popup_notification():
+                    """
+                    通知本地回调服务器已显示受控弹窗。
+
+                    尝试短延迟 TCP 连接到 127.0.0.1:CALLBACK_PORT 并发送描述弹窗的 4 字节大端长度前缀的 UTF-8 JSON 消息。
+                    JSON 包含：`event`（设为 "popup_show"）、`popup_id`、`popup_title`、`popup_message` 和 `popup_type`。
+                    任何异常都被捕获并记录；函数不抛出异常。
+                    """
                     import socket
                     import json
                     import time
@@ -965,6 +1515,11 @@ def start_tcp_server(bb_window, port=25001):
             # 免责声明自动关闭
             if '免责声明' in title:
                 def auto_disclaimer():
+                    """
+                    短暂延迟后自动确认免责声明弹窗。
+
+                    等待两秒，然后将由闭包范围的 `popup_id` 标识的弹窗标记为已解决，操作动作为 'ok'。
+                    """
                     time.sleep(2)
                     _resolve_popup(popup_id, 'ok')
                 threading.Thread(target=auto_disclaimer, daemon=True).start()
@@ -972,6 +1527,11 @@ def start_tcp_server(bb_window, port=25001):
             # showwarning/showerror/showinfo 单按钮弹窗延迟1秒自动关闭
             if func_name in ['showinfo', 'showwarning', 'showerror']:
                 def auto_close_single_button():
+                    """
+                    等待一秒，然后使用 'ok' 操作解决关联的弹窗。
+
+                    此函数用于通过在 1 秒延迟后将其弹窗条目标记为 'ok' 结果来自动关闭单按钮对话框。
+                    """
                     time.sleep(1)
                     _resolve_popup(popup_id, 'ok')
                 threading.Thread(target=auto_close_single_button, daemon=True).start()
@@ -980,6 +1540,24 @@ def start_tcp_server(bb_window, port=25001):
         return wrapper
 
     def _create_controlled_dialog(func_name, title, message, popup_id, original_func, **kwargs):
+        """
+        显示可外部解决的受控 tkinter messagebox，可选地通知回调监听器。
+
+        通过调用 `original_func(title, message, **kwargs)` 显示对话框，同时监控模块弹窗协调状态以获取 `popup_id`，
+        解决后关闭对话框窗口（如果存在），从内部队列中移除弹窗，并可选地向配置的 CALLBACK_PORT 发送帧式 JSON 回调。
+        调用将在返回前短暂等待监视器动作。
+
+        参数:
+            func_name (str): messagebox 变体的标识符（例如 'askyesno'、'askokcancel'、'showinfo'）。
+            title (str): 用于定位和关闭对话框的窗口标题。
+            message (str): 传递给对话框的消息文本。
+            popup_id (str): 模块弹窗跟踪字典/队列中使用的唯一 ID。
+            original_func (callable): 要调用的原始 tkinter.messagebox 函数（签名：title, message, **kwargs）。
+            **kwargs: 转发到 `original_func` 的附加关键字参数。
+
+        返回:
+            bool 或 None: 对于 'askyesno'、'askokcancel' 和 'askretrycancel'，如果弹窗被肯定解决则返回 `True`，否定解决返回 `False`，未解决则返回 `None`；对于其他对话框类型返回 `None`。
+        """
         import ctypes
         import time
         user32 = ctypes.windll.user32
@@ -987,10 +1565,25 @@ def start_tcp_server(bb_window, port=25001):
         popup_data = {'value': None, 'resolved': False}
 
         def is_window_exists(window_title):
+            """
+            检查具有确切 Unicode 标题的顶级窗口是否存在。
+
+            参数:
+                window_title (str): 要匹配的精确窗口标题（Unicode 字符串）。
+
+            返回:
+                bool: 如果具有给定标题的顶级窗口存在则返回 `True`，否则返回 `False`。
+            """
             hwnd = user32.FindWindowW(None, window_title)
             return hwnd != 0
 
         def monitor():
+            """
+            等待受控弹窗被解决，如果存在则关闭其窗口，从弹窗队列中移除，并可选地通知本地回调端口。
+
+            轮询模块的弹窗等待字典以获取此弹窗的解决状态；解决后，向弹窗窗口（如果找到）发送 WM_CLOSE，等待窗口消失，
+            从共享队列中移除弹窗，并且——如果设置了 CALLBACK_PORT——触发回调通知器，发送描述关闭的长度前缀 JSON 事件。
+            """
             while not popup_data['resolved']:
                 with _popup_wait_lock:
                     info = _popup_wait_dict.get(popup_id)
@@ -1015,6 +1608,14 @@ def start_tcp_server(bb_window, port=25001):
 
             if CALLBACK_PORT:
                 def send_callback():
+                    """
+                    通知外部回调服务器弹窗已关闭。
+
+                    构建包含 `event`、`popup_id`、`popup_title`、`popup_result` 和 `window_closed` 的 JSON 事件；
+                    如果标题包含"免责声明"则事件为 `disclaimer_closed` 并包含 `bbc_ready: True`。
+                    通过 TCP 连接到 127.0.0.1:CALLBACK_PORT，并使用模块的 4 字节大端长度前缀 JSON 帧格式发送事件。
+                    记录成功或任何失败；不抛出异常。
+                    """
                     import socket
                     import json
                     time.sleep(0.5)
@@ -1049,11 +1650,11 @@ def start_tcp_server(bb_window, port=25001):
         _remove_popup_from_queue(popup_id)
         result = popup_data['value'] if popup_data['resolved'] else None
         if func_name == 'askyesno':
-            return result == True  # BBC askyesno 返回 True/False 布尔值
+            return bool(result)  # BBC askyesno 返回 True/False 布尔值
         elif func_name == 'askokcancel':
-            return result == True  # BBC askokcancel 返回 True/False 布尔值
+            return bool(result)  # BBC askokcancel 返回 True/False 布尔值
         elif func_name == 'askretrycancel':
-            return result == True
+            return bool(result)
         return None
 
     messagebox.showinfo = create_popup_wrapper('showinfo', original_messagebox['showinfo'])
@@ -1069,6 +1670,13 @@ def start_tcp_server(bb_window, port=25001):
 
     if CALLBACK_PORT:
         def send_callback():
+            """
+            Notify a local callback listener that the TCP server has started.
+            
+            Sleeps 0.5 seconds, then connects to 127.0.0.1:CALLBACK_PORT and sends a 4-byte big-endian length-prefixed UTF-8 JSON payload:
+            {'event': 'server_started', 'server_port': port, 'bbc_ready': _bb_window_global is not None}.
+            Logs an info message on success and a warning on failure. No value is returned.
+            """
             import socket
             import json
             import time


### PR DESCRIPTION
新功能
自动化BBC战斗编排，具限重试、弹出感知处理和结果传播
完整的BBC生命周期控制：启动、停止、重启并自动重连和模拟器验证
本地长度前缀的TCP控制协议，提供连接、配置、战斗、弹出和状态API，支持弹出转发/解析
具备消息排队、回调传递和进程监督功能的持久TCP/连接管理器
CLI 代理入口点和 GUI 集成的紧凑标准日志
模拟器连接工具和安全过程清理功能