### PR TITLE
Fix: manager is not defined error

### DIFF
--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -132,7 +132,12 @@ class ExecuteBbcTask(CustomAction):
                 popup_message = msg.get('popup_message', '')
                 mfaalog.info(f"[ExecuteBbcTask] 收到弹窗: {popup_title} - {popup_message}")
                 if not state['finished']:
-                    self._handle_popups([msg], support_order_mismatch, team_config_error, state, manager)
+                    try:
+                        # 尝试获取 manager 实例
+                        local_manager = get_manager()
+                        self._handle_popups([msg], support_order_mismatch, team_config_error, state, local_manager)
+                    except Exception as e:
+                        mfaalog.error(f"[ExecuteBbcTask] 处理弹窗时出错: {e}")
                     state['popup_event'].set()  # 通知监听线程
             
             manager.set_popup_callback(on_popup)
@@ -531,6 +536,9 @@ class ExecuteBbcTask(CustomAction):
     
     def _wait_for_battle_end(self, state: dict):
         """等待战斗结束 - 心跳检查和弹窗处理分离"""
+        
+        # 获取 manager 实例
+        manager = get_manager()
         
         # 主线程：只做心跳检查
         heartbeat_interval = 30  # 30秒一次心跳


### PR DESCRIPTION
## 错误修复：manager is not defined 错误
### 问题描述
在 bbc_action.py 文件中，出现了 name 'manager' is not defined 错误，导致战斗过程中系统崩溃。

### 错误原因
1. 主要原因 ：在 _wait_for_battle_end 方法中直接使用了未定义的 manager 变量
2. 次要原因 ：在 on_popup 回调函数中， manager 变量可能在战斗结束后超出作用域 ### 修复方案
1. 修改 on_popup 回调函数 ：

   - 不再依赖外部 manager 变量
   - 在回调函数内部通过 get_manager() 重新获取管理器实例
   - 添加 try-except 块捕获可能的异常
2. 修改 _wait_for_battle_end 方法 ：

   - 在方法内部添加 manager = get_manager() 来获取管理器实例
   - 确保在方法内部能够正确访问 manager 变量 ### 修复效果
- 解决了 name 'manager' is not defined 错误
- 提高了代码的健壮性和可靠性
- 确保在战斗过程中心跳检查能够正常执行
- 确保即使在战斗结束后，弹窗回调函数仍然能够正常工作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 改进了弹出窗口消息处理的错误处理机制，增强了系统稳定性
* 优化了心跳命令执行流程，确保资源正确管理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->