### PR TITLE
fix: maa-tools check 排除 Chaldea 目录

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Run maa-checker
         run: |
           npm ci
-          npx @nekosu/maa-tools check
+          # 排除 Chaldea 目录，只检查其他资源
+          npx @nekosu/maa-tools check --resource-dirs assets/resource/base,assets/resource/cn,assets/resource/jp
 
       - name: Install maafw
         run: |


### PR DESCRIPTION
- 指定检查路径为 base/cn/jp，避免检查 Chaldea 目录的 agent 数据文件
- Chaldea 目录包含 servant_names_CN.json、equip_names_CN.json、map_coordinates.json 等 agent 使用的数据文件，不应进行资源验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂务**
  * 优化了资源检查工作流的配置。通过将检查范围限定至指定的资源库目录，提高了持续集成流程的执行效率。此项调整改进了整体构建过程的性能表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->