### PR TITLE
fix: update_chaldea_data.py 输出路径修正为 agent/utils/Chaldea/

### DIFF
--- a/tools/update_chaldea_data.py
+++ b/tools/update_chaldea_data.py
@@ -24,9 +24,9 @@ if sys.stdout.encoding != 'utf-8':
 
 ATLAS_API = "https://api.atlasacademy.io"
 
-# 输出目录：assets/resource/Chaldea/
+# 输出目录：agent/utils/Chaldea/
 _TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
-DATA_DIR = os.path.join(_TOOLS_DIR, "..", "assets", "resource", "Chaldea")
+DATA_DIR = os.path.join(_TOOLS_DIR, "..", "agent", "utils", "Chaldea")
 
 
 def fetch_json(url: str, timeout: int = 60) -> list | dict:

--- a/tools/update_chaldea_data.py
+++ b/tools/update_chaldea_data.py
@@ -24,7 +24,7 @@ if sys.stdout.encoding != 'utf-8':
 
 ATLAS_API = "https://api.atlasacademy.io"
 
-# 输出目录：agent/utils/Chaldea/
+# 输出目录: agent/utils/Chaldea/
 _TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(_TOOLS_DIR, "..", "agent", "utils", "Chaldea")
 

--- a/tools/update_chaldea_data.py
+++ b/tools/update_chaldea_data.py
@@ -2,7 +2,7 @@
 Chaldea 本地名称数据库更新工具
 
 从 Atlas Academy API 下载国服从者和礼装的名称数据，
-保存为 agent/data/ 下的本地 JSON 文件。
+保存为 agent/utils/Chaldea/ 下的本地 JSON 文件。
 
 运行一次即可建立/更新本地数据库，之后转换器无需网络即可查询名称。
 


### PR DESCRIPTION
- Chaldea 数据文件实际位于 agent/utils/Chaldea/
- 更新脚本输出路径与 game_data.py 读取路径保持一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 调整生成的数据文件的存放位置：已将工具生成的 JSON 输出迁移到新的数据目录，相关目录创建与提示流程已更新。此变更仅影响文件存储路径，不改变文件格式或应用行为，用户无需修改现有配置或使用方式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->