### PR TITLE
refactor: BBC 战斗类型与连接方式直接使用索引和命令名

### DIFF
--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -83,7 +83,7 @@ class ExecuteBbcTask(CustomAction):
             team_config = attach_data.get('bbc_team_config', '')
             run_count = attach_data.get('run_count')
             apple_type = attach_data.get('apple_type')
-            battle_type = attach_data.get('battle_type', '连续出击')
+            battle_type = attach_data.get('battle_type', 0)  # 直接使用索引值 (0, 1, 2...)
             
             # 直接使用配置文件中的布尔值（BBC Server 需要 True/False）
             support_order_mismatch = attach_data.get('support_order_mismatch', False)
@@ -264,17 +264,8 @@ class ExecuteBbcTask(CustomAction):
         emulator_params = device_info.get('emulator_params', {})
         
         if emulator_params:
-            # 提取用户配置的参数
-            connect = attach_data.get('connect', 'auto')
-            connect_cmd_map = {
-                'mumu': 'connect_mumu',
-                'ld': 'connect_ld',
-                'adb': 'connect_adb',
-                'connect_mumu': 'connect_mumu',
-                'connect_ld': 'connect_ld',
-                'connect_adb': 'connect_adb'
-            }
-            connect_cmd = connect_cmd_map.get(connect, connect)
+            # 提取用户配置的参数（直接使用标准命令名）
+            connect_cmd = attach_data.get('connect', 'auto')  # connect_mumu / connect_ld / connect_adb / auto
             
             expected_args = {}
             if connect_cmd == 'connect_mumu':
@@ -304,17 +295,8 @@ class ExecuteBbcTask(CustomAction):
         
         mfaalog.warning("[ExecuteBbcTask] 模拟器未连接或参数不匹配，调用Manager重启BBC...")
         
-        # 提取连接参数
-        connect = attach_data.get('connect', 'auto')
-        connect_cmd_map = {
-            'mumu': 'connect_mumu',
-            'ld': 'connect_ld',
-            'adb': 'connect_adb',
-            'connect_mumu': 'connect_mumu',
-            'connect_ld': 'connect_ld',
-            'connect_adb': 'connect_adb'
-        }
-        connect_cmd = connect_cmd_map.get(connect, connect)
+        # 提取连接参数（直接使用标准命令名）
+        connect_cmd = attach_data.get('connect', 'auto')  # connect_mumu / connect_ld / connect_adb / auto
         
         connect_args = {}
         if connect_cmd == 'connect_mumu':

--- a/agent/custom/bbc_start.py
+++ b/agent/custom/bbc_start.py
@@ -28,8 +28,8 @@ class StartBbc(CustomAction):
             
             attach_data = node_data.get('attach', {})
             
-            # 提取连接相关参数
-            connect = attach_data.get('connect', 'auto')
+            # 提取连接相关参数（直接使用标准命令名）
+            connect_cmd = attach_data.get('connect', 'auto')  # connect_mumu / connect_ld / connect_adb / auto
             mumu_path = attach_data.get('mumu_path', '')
             mumu_index = attach_data.get('mumu_index', 0)
             mumu_pkg = attach_data.get('mumu_pkg', 'com.bilibili.fatego')
@@ -37,19 +37,6 @@ class StartBbc(CustomAction):
             ld_path = attach_data.get('ld_path', '')
             ld_index = attach_data.get('ld_index', 0)
             manual_port = attach_data.get('manual_port', '')
-            
-            # 将连接类型转换为 BBC 服务端命令
-            connect_cmd_map = {
-                'mumu': 'connect_mumu',
-                'ld': 'connect_ld',
-                'ldplayer': 'connect_ld', 
-                'adb': 'connect_adb',
-                'manual': 'connect_adb',
-                'connect_mumu': 'connect_mumu',
-                'connect_ld': 'connect_ld',
-                'connect_adb': 'connect_adb'
-            }
-            connect_cmd = connect_cmd_map.get(connect, connect)
             
             # 构建连接参数
             connect_args = {}

--- a/assets/options/bbc_battle_type.json
+++ b/assets/options/bbc_battle_type.json
@@ -7,22 +7,77 @@
             "cases": [
                 {
                     "name": "连续出击",
-                    "label": "连续出击",
+                    "label": "连续出击(或强化本)",
                     "pipeline_override": {
                         "执行BBC任务": {
                             "attach": {
-                                "battle_type": "continuous"
+                                "battle_type": 0
                             }
                         }
                     }
                 },
                 {
-                    "name": "自动编队爬塔",
-                    "label": "自动编队爬塔",
+                    "name": "自动编队爬塔_应用操作序列",
+                    "label": "自动编队爬塔(应用操作序列设置)",
                     "pipeline_override": {
                         "执行BBC任务": {
                             "attach": {
-                                "battle_type": "tower"
+                                "battle_type": 1
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "自动编队爬塔_程序自主",
+                    "label": "自动编队爬塔(程序自主技能宝具)",
+                    "pipeline_override": {
+                        "执行BBC任务": {
+                            "attach": {
+                                "battle_type": 2
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "幕间物语",
+                    "label": "幕间物语(部分需手动)",
+                    "pipeline_override": {
+                        "执行BBC任务": {
+                            "attach": {
+                                "battle_type": 3
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "清自由本",
+                    "label": "清自由本(不包括2.7)",
+                    "pipeline_override": {
+                        "执行BBC任务": {
+                            "attach": {
+                                "battle_type": 4
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "类主线",
+                    "label": "类主线(部分情况手动)",
+                    "pipeline_override": {
+                        "执行BBC任务": {
+                            "attach": {
+                                "battle_type": 5
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "主线物语大奥",
+                    "label": "主线物语·大奥(部分情况手动)",
+                    "pipeline_override": {
+                        "执行BBC任务": {
+                            "attach": {
+                                "battle_type": 6
                             }
                         }
                     }

--- a/assets/options/bbc_battle_type.json
+++ b/assets/options/bbc_battle_type.json
@@ -3,10 +3,11 @@
         "bbc_battle_type": {
             "type": "select",
             "label": "战斗类型",
-            "default": "连续出击",
+            "default": "连续出击(或强化本)",
+            "description": "当前连续出击之外的战斗类型在实际使用中没有意义。目前的使用都是针对自由关设计",
             "cases": [
                 {
-                    "name": "连续出击",
+                    "name": "连续出击(或强化本)",
                     "label": "连续出击(或强化本)",
                     "pipeline_override": {
                         "执行BBC任务": {

--- a/assets/options/connect_method.json
+++ b/assets/options/connect_method.json
@@ -28,7 +28,7 @@
                     "pipeline_override": {
                         "启动bbc": {
                             "attach": {
-                                "connect": "mumu"
+                                "connect": "connect_mumu"
                             }
                         }
                     }
@@ -43,7 +43,7 @@
                     "pipeline_override": {
                         "启动bbc": {
                             "attach": {
-                                "connect": "ldplayer"
+                                "connect": "connect_ld"
                             }
                         }
                     }
@@ -57,7 +57,7 @@
                     "pipeline_override": {
                         "启动bbc": {
                             "attach": {
-                                "connect": "manual"
+                                "connect": "connect_adb"
                             }
                         }
                     }

--- a/bbcdll/bbc_tcp_server.py
+++ b/bbcdll/bbc_tcp_server.py
@@ -380,7 +380,7 @@ class ConfigAPI:
 
 
 class BattleSettingsAPI:
-    VALID_APPLE_TYPES = {"gold", "silver", "blue", "copper", "colorful"}
+    VALID_APPLE_TYPES = frozenset({"gold", "silver", "blue", "copper", "colorful"})
 
     @staticmethod
     def set_apple_type(apple_type):

--- a/bbcdll/bbc_tcp_server.py
+++ b/bbcdll/bbc_tcp_server.py
@@ -101,7 +101,15 @@ def ensure_imports():
             Copper = "copper"
             Blue = "blue"
             Colorful = "colorful"
-            BATTLE_TYPE = ['连续出击(或强化本)', '自动编队爬塔(应用操作序列设置)']
+            BATTLE_TYPE = [
+                '连续出击(或强化本)',
+                '自动编队爬塔(应用操作序列设置)',
+                '自动编队爬塔(程序自主技能宝具)',
+                '幕间物语(部分需手动)',
+                '清自由本(不包括2.7)',
+                '类主线(部分情况手动)',
+                '主线物语·大奥(部分情况手动)'
+            ]
         CT = MockCT()
     try:
         from device import Windows, LDdevice, Mumudevice
@@ -372,20 +380,7 @@ class ConfigAPI:
 
 
 class BattleSettingsAPI:
-    APPLE_MAP = {
-        "gold": "gold",
-        "silver": "silver",
-        "blue": "blue",
-        "copper": "copper",
-        "colorful": "colorful"
-    }
-
-    BATTLE_TYPE_MAP = {
-        "continuous": 0,
-        "tower": 1,
-        "连续出击": 0,
-        "自动编队爬塔": 1
-    }
+    VALID_APPLE_TYPES = {"gold", "silver", "blue", "copper", "colorful"}
 
     @staticmethod
     def set_apple_type(apple_type):
@@ -393,7 +388,7 @@ class BattleSettingsAPI:
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
-        if apple_type not in BattleSettingsAPI.APPLE_MAP:
+        if apple_type not in BattleSettingsAPI.VALID_APPLE_TYPES:
             return {'success': False, 'error': f'Unknown apple type: {apple_type}'}
         try:
             page.appleSet.appleType = CT.Gold if apple_type == "gold" else getattr(CT, apple_type.capitalize(), CT.Gold)
@@ -426,13 +421,14 @@ class BattleSettingsAPI:
         page = get_bb_page()
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
-        if battle_type not in BattleSettingsAPI.BATTLE_TYPE_MAP:
-            return {'success': False, 'error': f'Unknown battle type: {battle_type}'}
         try:
-            idx = BattleSettingsAPI.BATTLE_TYPE_MAP[battle_type]
+            # battle_type 直接是索引值 (0, 1, 2...)
+            idx = int(battle_type)
+            if idx < 0 or idx >= len(CT.BATTLE_TYPE):
+                return {'success': False, 'error': f'Invalid battle type index: {idx}'}
             page.battletype.set(CT.BATTLE_TYPE[idx])
-            _log('info', f'[Battle] Battle type set: {battle_type}')
-            return {'success': True, 'battle_type': battle_type}
+            _log('info', f'[Battle] Battle type set: index={idx}, name={CT.BATTLE_TYPE[idx]}')
+            return {'success': True, 'battle_type_index': idx}
         except Exception as e:
             return {'success': False, 'error': str(e)}
 

--- a/bbcdll/bbc_tcp_server.py
+++ b/bbcdll/bbc_tcp_server.py
@@ -443,11 +443,14 @@ class BattleSettingsAPI:
         if page is None:
             return {'success': False, 'error': 'BBC window not ready'}
         try:
+            # 将 UI 中的文本标签转换回索引
+            current_label = page.battletype.get()
+            battle_type_index = CT.BATTLE_TYPE.index(current_label) if current_label in CT.BATTLE_TYPE else -1
             return {
                 'success': True,
                 'apple_type': page.appleSet.appleType,
                 'run_times': page.appleSet.runTimes.get(),
-                'battle_type': page.battletype.get()
+                'battle_type_index': battle_type_index
             }
         except Exception as e:
             return {'success': False, 'error': str(e)}
@@ -528,10 +531,12 @@ class StatusAPI:
 
             battle_settings = {}
             try:
+                current_label = str(page.battletype.get())
+                battle_type_index = CT.BATTLE_TYPE.index(current_label) if current_label in CT.BATTLE_TYPE else -1
                 battle_settings = {
                     'apple_type': str(page.appleSet.appleType),
                     'run_times': page.appleSet.runTimes.get(),
-                    'battle_type': str(page.battletype.get())
+                    'battle_type_index': battle_type_index
                 }
             except:
                 pass

--- a/bbcdll/bbc_tcp_server.py
+++ b/bbcdll/bbc_tcp_server.py
@@ -424,8 +424,13 @@ class BattleSettingsAPI:
         try:
             # battle_type 直接是索引值 (0, 1, 2...)
             idx = int(battle_type)
-            if idx < 0 or idx >= len(CT.BATTLE_TYPE):
-                return {'success': False, 'error': f'Invalid battle type index: {idx}'}
+        except (ValueError, TypeError):
+            return {'success': False, 'error': f'Invalid battle type value: {battle_type}'}
+        
+        if idx < 0 or idx >= len(CT.BATTLE_TYPE):
+            return {'success': False, 'error': f'Battle type index out of range: {idx} (valid: 0-{len(CT.BATTLE_TYPE)-1})'}
+        
+        try:
             page.battletype.set(CT.BATTLE_TYPE[idx])
             _log('info', f'[Battle] Battle type set: index={idx}, name={CT.BATTLE_TYPE[idx]}')
             return {'success': True, 'battle_type_index': idx}

--- a/tools/update_chaldea_data.py
+++ b/tools/update_chaldea_data.py
@@ -24,9 +24,9 @@ if sys.stdout.encoding != 'utf-8':
 
 ATLAS_API = "https://api.atlasacademy.io"
 
-# 输出目录：assets/resource/Chaldea/
+# 输出目录：agent/utils/Chaldea/
 _TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
-DATA_DIR = os.path.join(_TOOLS_DIR, "..", "assets", "resource", "Chaldea")
+DATA_DIR = os.path.join(_TOOLS_DIR, "..", "agent", "utils", "Chaldea")
 
 
 def fetch_json(url: str, timeout: int = 60) -> list | dict:

--- a/tools/update_chaldea_data.py
+++ b/tools/update_chaldea_data.py
@@ -24,7 +24,7 @@ if sys.stdout.encoding != 'utf-8':
 
 ATLAS_API = "https://api.atlasacademy.io"
 
-# 输出目录：agent/utils/Chaldea/
+# 输出目录: agent/utils/Chaldea/
 _TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(_TOOLS_DIR, "..", "agent", "utils", "Chaldea")
 


### PR DESCRIPTION
## 变更说明

- **删除 BATTLE_TYPE_MAP 映射**：battle_type 直接使用索引值 (0-6)
- **删除 connect_cmd_map 映射**：connect 直接使用标准命令名 (connect_mumu/connect_ld/connect_adb)
- **优化 APPLE_MAP**：改为 VALID_APPLE_TYPES 集合（仅白名单校验，非映射）
- **同步更新**：options 配置文件和 MockCT 定义
- **全链路无映射转换**：options  Action  Manager  BBC Server 全部直接透传

## 影响范围
- agent/custom/bbc_action.py
- agent/custom/bbc_start.py
- assets/options/bbc_battle_type.json
- assets/options/connect_method.json
- bbcdll/bbc_tcp_server.py

## Summary by Sourcery

重构 BBC 战斗和连接配置，移除中间映射层，直接依赖索引/命令名称，同时扩展支持的战斗类型并更新数据路径。

新功能：
- 在 BBC MockCT 配置中新增更多战斗类型名称，以支持更多战斗模式。

改进：
- 通过简单的白名单验证苹果类型，而不是使用映射表。
- 在请求和日志中直接使用战斗类型索引，而不是通过字符串到索引的映射。
- 将模拟器连接方式直接作为标准命令名称传递，而不是从别名映射得到。
- 更新 Chaldea 数据生成脚本，将输出写入 `agent/utils/Chaldea` 下，而不是 `assets/resource/Chaldea`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor BBC battle and connection configuration to remove mapping layers and rely on direct indices/command names, while expanding supported battle types and updating data paths.

New Features:
- Add additional battle type names to the BBC MockCT configuration for more battle modes.

Enhancements:
- Validate apple types via a simple whitelist instead of a mapping table.
- Use battle type indices directly in requests and logging instead of string-to-index mappings.
- Pass emulator connection method as a direct standard command name instead of mapping from aliases.
- Update the Chaldea data generation script to write output under agent/utils/Chaldea instead of assets/resource/Chaldea.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 扩展了战斗类型选项，新增多个“自动编队爬塔”变体及更多战斗类别（如幕间物语、清自由本、类主线、主线物语大奥）。

* **改进**
  * 战斗类型配置改为使用数值编码以提升一致性，界面与校验更严格。
  * 连接方式选项调整为标准化命令名，连接选择与启动流程更明确。
  * 设置接口在返回值与校验上进行了调整，响应中使用战斗类型索引以便统一处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->