### PR TITLE
fix(mission-solver): address code review comments

### DIFF
--- a/agent/mission_solver/__main__.py
+++ b/agent/mission_solver/__main__.py
@@ -49,7 +49,7 @@ def main():
     if not missions:
         print("未找到当前周的周常任务数据。")
         print("请确认:")
-        print(f"  1. 数据文件存在: agent/mission_solver/master_missions_{args.region}.json")
+        print(f"  1. 数据文件存在: assets/resource/Chaldea/master_missions_{args.region}.json")
         print("  2. 当前日期有对应的周常任务")
         sys.exit(1)
 

--- a/agent/mission_solver/solver.py
+++ b/agent/mission_solver/solver.py
@@ -69,9 +69,9 @@ def solve(quests: list[QuestPhase], missions: list[Mission]) -> SolveResult:
     # 调用 HiGHS 求解
     try:
         import highspy
-    except ImportError as err:
-        logger.error("highspy 未安装，请运行: pip install highspy", exc_info=err)
-        raise ImportError("请安装 highspy: pip install highspy") from err
+    except ImportError:
+        logger.error("highspy 未安装，请运行: pip install highspy")
+        raise ImportError("请安装 highspy: pip install highspy")
 
     h = highspy.Highs()
     h.silent()

--- a/tools/update_quest_data.py
+++ b/tools/update_quest_data.py
@@ -2,7 +2,7 @@
 副本敌人数据 & 周常任务数据更新工具
 
 从 Atlas Academy API 下载国服 Free 副本的敌人信息和周常任务历史数据。
-保存到 agent/mission_solver/ 目录，供周常任务求解器离线使用。
+保存到 assets/resource/Chaldea/ 目录，供周常任务求解器离线使用。
 
 用法:
     python tools/update_quest_data.py
@@ -28,7 +28,7 @@ ATLAS_API = "https://api.atlasacademy.io"
 CHALDEA_DATA_HOST = "https://data.chaldea.center"
 
 _TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
-DATA_DIR = os.path.join(_TOOLS_DIR, "..", "agent", "mission_solver")
+DATA_DIR = os.path.join(_TOOLS_DIR, "..", "assets", "resource", "Chaldea")
 
 # 主线 War ID 范围（国服）
 # War 100-399: 主线章节 (特异点/Lostbelt)
@@ -197,7 +197,7 @@ def update_quest_enemies(region: str = "CN"):
                 free_quests.append(quest)
 
         if not free_quests:
-            print("无 Free 副本")
+            print(f"无 Free 副本")
             continue
 
         print(f"{len(free_quests)} 个 Free 副本")


### PR DESCRIPTION
## Summary by Sourcery

根据新的任务数据资源文件位置调整任务求解工具和相关消息，并简化 `highspy` 导入错误的处理。

Bug 修复：
- 更正工具和 CLI 消息中的任务与关卡数据路径，使其指向 `assets/resource/Chaldea`，而不是旧的 `agent/mission_solver` 目录。

功能增强：
- 通过在任务求解器中避免异常链式传递，简化 `highspy` 的 `ImportError` 日志记录。
- 优化关卡更新工具在没有 Free 关卡时的输出消息格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align mission solver tooling and messages with new quest data asset location and simplify highspy import error handling.

Bug Fixes:
- Correct quest and mission data paths in tooling and CLI messages to point to assets/resource/Chaldea instead of the old agent/mission_solver directory.

Enhancements:
- Simplify logging on highspy ImportError by avoiding exception chaining in the mission solver.
- Polish quest update tool output message formatting for cases with no Free quests.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 优化了错误处理逻辑，简化异常信息链
* 调整了资源文件存储配置路径

**总计：2 处内部改进，无功能变更**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->