### PR TITLE
fix: 修正变量引用错误和类型注解

### DIFF
--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -331,7 +331,7 @@ class ExecuteBbcTask(CustomAction):
             return False
     
     def _setup_and_start_battle(self, team_config: str, run_count: int, 
-                                apple_type: str, battle_type: str,
+                                apple_type: str, battle_type: int,
                                 support_order_mismatch: bool, team_config_error: bool,
                                 state: dict, manager) -> dict:
         

--- a/agent/custom/bbc_start.py
+++ b/agent/custom/bbc_start.py
@@ -61,7 +61,7 @@ class StartBbc(CustomAction):
                     'mode': 'auto'
                 }
             
-            mfaalog.info(f"[StartBbc] 连接参数: connect={connect}, cmd={connect_cmd}")
+            mfaalog.info(f"[StartBbc] 连接参数: cmd={connect_cmd}")
             mfaalog.info(f"[StartBbc] MuMu: path={mumu_path}, index={mumu_index}, pkg={mumu_pkg}")
             mfaalog.info(f"[StartBbc] LD: path={ld_path}, index={ld_index}")
             


### PR DESCRIPTION
- bbc_start.py: 删除未定义的 connect 变量引用
- bbc_action.py: 修正 battle_type 参数类型从 str 改为 int

## Summary by Sourcery

修复错误的变量日志记录，并更正战斗配置中函数参数的类型。

Bug 修复：
- 移除在 `bbc_start` 运行流程中记录未定义变量 `connect` 的日志。
- 将战斗设置函数中的 `battle_type` 参数从字符串更改为整数，以匹配预期用法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix incorrect variable logging and correct a function parameter type for battle configuration.

Bug Fixes:
- Remove logging of an undefined connect variable in bbc_start run flow.
- Change battle_type parameter from string to integer in battle setup function to match expected usage.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 更正了类型注解，确保参数类型与实际使用方式保持一致。

* **杂项**
  * 简化了日志输出，移除了冗余的日志变量。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->