### PR TITLE
chore:从 CI 工作流中移除 MFAAvalonia 构建，将发布产物简化为仅包含 MWU 和 MXU 构建。

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -158,7 +158,7 @@ jobs:
         shell: bash
         run: |
           tag="${{ env.tag }}"
-          version=$(echo "$tag" | sed 's/^v//; s/Avalonia$//; s/MWU$//')
+          version=$(echo "$tag" | sed 's/^v//; s/MWU$//')
           echo "clean_version=$version" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
@@ -268,7 +268,7 @@ jobs:
         shell: bash
         run: |
           tag="${{ env.tag }}"
-          version=$(echo "$tag" | sed 's/^v//; s/Avalonia$//; s/MWU$//')
+          version=$(echo "$tag" | sed 's/^v//; s/MWU$//')
           echo "clean_version=$version" >> $GITHUB_OUTPUT
 
       - name: Upload MXU Artifacts
@@ -277,101 +277,6 @@ jobs:
           name: ${{ env.repo_name }}-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.clean_version }}-MXU
           path: "./install-mxu/*"
 
-  build-avalonia:
-    needs: meta
-    env:
-      repo_name: ${{ needs.meta.outputs.repo_name }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        include:
-          - os: win
-            arch: x86_64
-            runner: windows-latest
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - name: Download MaaFramework
-        id: download_mfw
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: MaaXYZ/MaaFramework
-          fileName: "MAA-${{ matrix.os }}-${{ matrix.arch }}*"
-          latest: true
-          out-file-path: "deps"
-          extract: true
-
-      - name: Flatten MaaFramework directory
-        shell: bash
-        run: |
-          # 查找解压后的 MaaFramework 目录并移动内容到 deps 根目录
-          MFW_DIR=$(find deps -maxdepth 1 -type d -name "MAA-*" | head -n 1)
-          if [ -n "$MFW_DIR" ] && [ "$MFW_DIR" != "deps" ]; then
-            echo "Moving contents from $MFW_DIR to deps/"
-            mv "$MFW_DIR"/* deps/
-            mv "$MFW_DIR"/.* deps/ 2>/dev/null || true
-            rmdir "$MFW_DIR"
-          fi
-          ls -la deps/
-
-      - name: Download Python Dependencies
-        shell: bash
-        run: |
-          python tools/download_deps.py ${{ matrix.os }} ${{ matrix.arch }}
-
-      - name: Download FGO-MFAAvalonia
-        id: download_mfa
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: MaaXYZ/MFAAvalonia
-          fileName: "MFAAvalonia-*-win-${{ (matrix.arch == 'x86_64' && 'x64') || (matrix.arch == 'aarch64' && 'arm64') }}*"
-          latest: true
-          out-file-path: "MFA"
-          extract: true
-
-      - name: Clean up MFAAvalonia archive
-        shell: bash
-        run: |
-          ARCHIVE_FILE_PATH="${{ fromJson(steps.download_mfa.outputs.downloaded_files)[0] }}"
-          rm -f "${ARCHIVE_FILE_PATH}"
-          echo "Archive cleanup command executed for MFAAvalonia."
-
-      - name: Setup & Install Avalonia
-        shell: bash
-        run: |
-          # 1. 配置嵌入式 Python (仅下载和解压)
-          python tools/setup_embed_python.py install/python ${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64' }}
-          
-          # 2. 安装依赖 (M9A 模式：直接在 CI 环境中通过 pip 安装到嵌入式 Python)
-          ./install/python/python.exe install/python/get-pip.py
-          ./install/python/python.exe -m pip install --upgrade pip
-          ./install/python/python.exe -m pip install -r requirements.txt
-          
-          # 3. 准备 MFA 文件（-n 不覆盖已存在的 python 目录）
-          mkdir -p install
-          cp -rpvn MFA/. install/
-          rm -rf install/runtimes
-          
-          # 4. 调用脚本完成资源组装
-          python tools/install-Avalonia.py ${{ needs.meta.outputs.tag }} ${{ matrix.os }} ${{ matrix.arch }}
-
-      - name: Get version without suffix
-        id: get_version
-        shell: bash
-        run: |
-          tag="${{ needs.meta.outputs.tag }}"
-          version=$(echo "$tag" | sed 's/^v//; s/Avalonia$//; s/MWU$//')
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      - name: Upload Avalonia artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.repo_name }}-${{ matrix.os }}-${{ matrix.arch }}-v${{ steps.get_version.outputs.version }}-MFAA
-          path: "./install/*"
 
   changelog:
     name: Generate changelog
@@ -401,7 +306,7 @@ jobs:
   debug:
     if: ${{ needs.meta.outputs.is_release == 'false' }}
     runs-on: ubuntu-slim
-    needs: [meta, build-mwu, build-avalonia, build-mxu, changelog]
+    needs: [meta, build-mwu, build-mxu, changelog]
     steps:
       - name: Show Outputs
         run: |
@@ -413,7 +318,7 @@ jobs:
 
   release:
     if: ${{ needs.meta.outputs.is_release == 'true' }}
-    needs: [meta, build-mwu, build-avalonia, build-mxu, changelog]
+    needs: [meta, build-mwu, build-mxu, changelog]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8.0.1


### PR DESCRIPTION
删除工作流中的MFAAvalonia构建部分，仅保留MWU和MXU构建任务

## Summary by Sourcery

从 CI 工作流中移除 MFAAvalonia 构建，将发布产物简化为仅包含 MWU 和 MXU 构建。

CI：
- 更新标签版本规范化逻辑，不再在 MWU 和 MXU 构建任务中处理 Avalonia 后缀。
- 从 install 工作流中移除 `build-avalonia` 任务及其相关的制品上传步骤。
- 调整 debug 和 release 任务的依赖关系，去掉对已移除的 Avalonia 构建任务的依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the MFAAvalonia build from the CI workflow, simplifying release artifacts to MWU and MXU builds only.

CI:
- Update tag version normalization to no longer handle the Avalonia suffix in MWU and MXU build jobs.
- Remove the build-avalonia job and its related artifact upload from the install workflow.
- Adjust debug and release job dependencies to drop the removed Avalonia build job.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 简化了构建工作流程配置，优化了版本号处理逻辑。
  * 移除了不必要的构建步骤，提高了流程效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->