### PR TITLE
fix: 修复MWU打包cv2模块路径问题

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -1,10 +1,10 @@
 {
   "interface_version": 2,
   "name": "MaaFgo",
-  "description": "FGO自动战斗工具,模拟器需要强制为1080*720模式",
+  "description": "FGO自动战斗工具,模拟器需要强制为1280*720模式",
   "contact": "QQ群: 无",
   "license": "MIT",
-  "welcome": "首次使用！欢迎使用 MaaFgo!模拟器需要强制为1080*720模式!",
+  "welcome": "首次使用！欢迎使用 MaaFgo!模拟器需要强制为1280*720模式!",
   "github": "https://github.com/xlxyvergil/MaaFgo",
   "mirrorchyan_rid": "MaaFgo",
   "mirrorchyan_multiplatform": true,

--- a/tools/install-MWU.py
+++ b/tools/install-MWU.py
@@ -182,6 +182,16 @@ def install_restart_files():
             json.dump(config, f, ensure_ascii=False, indent=2)
 
 
+def fix_cv2_path():
+    """修复 cv2 模块路径：从 deps/cv2 移动到根目录"""
+    cv2_src = install_path / "deps" / "cv2"
+    cv2_dst = install_path / "cv2"
+    
+    if cv2_src.exists() and not cv2_dst.exists():
+        print(f"Moving cv2 from {cv2_src} to {cv2_dst}")
+        shutil.move(str(cv2_src), str(cv2_dst))
+
+
 if __name__ == "__main__":
     install_deps()
     install_resource()
@@ -189,5 +199,6 @@ if __name__ == "__main__":
     install_bbcdll()  # 复制 bbcdll 目录
     install_tasks()  # 复制 tasks 目录
     install_restart_files()  # 复制 restart 文件
+    fix_cv2_path()  # 修复 cv2 模块路径
 
     print(f"Install to {install_path} successfully.")


### PR DESCRIPTION
将deps/cv2移动到根目录，解决Nuitka打包后Python无法找到cv2模块的问题

## Summary by Sourcery

Bug Fixes:
- 当存在已安装的 `cv2` 包时，将其从 `deps/cv2` 移动到根安装目录，以修复经过 Nuitka 打包后出现的模块导入问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Move the installed cv2 package from deps/cv2 into the root install directory when present to fix module import issues after Nuitka packaging.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 更新了推荐的仿真器分辨率设置，提供更优的显示体验。
  * 优化了安装流程中的依赖库路径配置，确保组件正确加载。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xlxyvergil/MaaFgo/pull/42)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->