### PR TITLE
feat: 添加直接战斗任务并更新Dummy.json以支持新任务

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -49,6 +49,7 @@
     "tasks/关闭游戏.json",
     "tasks/冠位戴冠战.json",
     "tasks/迦勒底之门.json",
+    "tasks/直接战斗.json",
     "options/选择队伍配置.json",
     "options/chaldea_team_config.json",
     "options/chapter.json",

--- a/assets/resource/base/pipeline/Dummy.json
+++ b/assets/resource/base/pipeline/Dummy.json
@@ -1,4 +1,5 @@
 {
+    "全局空节点": {},
     "Global_Null": {
         "doc": "【全局默认空on_error覆盖】Jumpback链路崩毁默认节点",
         "pre_delay": 0,
@@ -8,16 +9,13 @@
             "其他异常"
         ]
     },
-    "其他异常": {
-        "focus": {
-            "Node.Recognition.Starting": "出现未知异常报错"
-        }
-    },
     "风暴罐不足": {
         "recognition": {
             "type": "TemplateMatch",
             "param": {
-                "template": "errorcode/风暴罐不足.png"
+                "template": [
+                    "errorcode/风暴罐不足.png"
+                ]
             }
         },
         "action": {
@@ -37,5 +35,10 @@
         "next": [
             "回主界面"
         ]
+    },
+    "其他异常": {
+        "focus": {
+            "Node.Recognition.Starting": "出现未知异常报错"
+        }
     }
 }

--- a/assets/tasks/直接战斗.json
+++ b/assets/tasks/直接战斗.json
@@ -1,0 +1,38 @@
+{
+  "task": [
+    {
+      "name": "直接bbc战斗",
+      "label": "直接bbc战斗",
+      "description": "直接打开bbc运行战斗，请确保当前已经处于助战或者编队界面（建议搭配启动bbc）",
+      "entry": "日常战斗",
+      "controller": [
+        "安卓设备"
+      ],
+      "option": [
+        "team_config",
+        "bbc_run_count",
+        "apple_type",
+        "bbc_battle_type",
+        "support_order_mismatch",
+        "team_config_error"
+      ],
+      "pipeline_override": {
+        "执行章节导航": {
+          "next": [
+            "全局空节点"
+          ]
+        },
+        "执行队伍选择": {
+          "next": [
+            "全局空节点"
+          ]
+        },
+        "执行回主界面": {
+          "next": [
+            "全局空节点"
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
[feat: 添加直接战斗任务并更新Dummy.json以支持新任务](https://github.com/xlxyvergil/MaaFgo/commit/7a0764340cd9f8a9ceb59b67727400a0c5410244)

## Summary by Sourcery

为新的直接战斗任务添加配置支持，并将其接入现有的任务/接口定义中。

新功能：
- 在任务配置中引入一个新的直接战斗任务定义。

增强内容：
- 更新 `Dummy.json` 管道配置以支持新的直接战斗任务。
- 调整接口配置以识别并暴露这个新任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration support for a new direct battle task and wire it into the existing task/interface definitions.

New Features:
- Introduce a new direct battle task definition in the tasks configuration.

Enhancements:
- Update Dummy.json pipeline configuration to support the new direct battle task.
- Adjust interface configuration to recognize and expose the new task.

</details>