### PR TITLE
feat: 冠位战添加最后一关的选项，现在可以选择它来打100⭐⭐⭐

### DIFF
--- a/assets/options/选择冠位难度.json
+++ b/assets/options/选择冠位难度.json
@@ -3,6 +3,7 @@
     "选择冠位难度": {
       "label": "$选择冠位难度",
       "type": "select",
+      "description": "最后一关会直接拉到最底选择，配置多个任务的话可以实现自动化推关",
       "cases": [
         {
           "name": "100⭐⭐",
@@ -37,6 +38,14 @@
                   ]
                 }
               }
+            }
+          }
+        },
+        {
+          "name": "最后一关",
+          "pipeline_override": {
+            "戴冠战-匹配检测": {
+              "recognition": "DirectHit"
             }
           }
         }


### PR DESCRIPTION
## Summary by Sourcery

新功能：
- 允许在冠位战中选择最终关卡选项，以便运行 100⭐ 关卡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow selecting the final stage option in 冠位战 to enable running the 100⭐ stage.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新增功能**
  * 冠位难度选项配置新增最后一关自动直接选择功能，支持多任务配置时实现自动推关。

* **功能改进**
  * 优化了最后一关的关卡识别机制，采用直接命中检测方式，提升识别精准度。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xlxyvergil/MaaFgo/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->