### PR TITLE
feat: 戴冠战最后一关逻辑优化，现在会正确跳过不能打的关

### DIFF
--- a/assets/resource/base/pipeline/冠位戴冠战.json
+++ b/assets/resource/base/pipeline/冠位戴冠战.json
@@ -1,4 +1,18 @@
 {
+    "戴冠战-确定弹窗有打开": {
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "template": [
+                    "grand/grand_cancel.png"
+                ]
+            }
+        },
+        "next": [
+            "戴冠战-匹配检测",
+            "戴冠战-不匹配关闭"
+        ]
+    },
     "冠位戴冠战-开始": {
         "focus": {
             "Node.Action.Starting": "<span style=\"color: #FF0000;\">开始戴冠战</span>"
@@ -239,13 +253,13 @@
                 ]
             }
         },
-        "post_delay": 1000,
+        "post_delay": 2000,
         "focus": {
             "Node.Action.Succeeded": "点击确认副本是否匹配"
         },
         "next": [
-            "戴冠战-匹配检测",
-            "戴冠战-不匹配关闭"
+            "戴冠战-确定弹窗有打开",
+            "戴冠战-不匹配上滑"
         ]
     },
     "戴冠战-错误": {

--- a/assets/resource/base/pipeline/冠位戴冠战.json
+++ b/assets/resource/base/pipeline/冠位戴冠战.json
@@ -1,18 +1,4 @@
 {
-    "戴冠战-确定弹窗有打开": {
-        "recognition": {
-            "type": "TemplateMatch",
-            "param": {
-                "template": [
-                    "grand/grand_cancel.png"
-                ]
-            }
-        },
-        "next": [
-            "戴冠战-匹配检测",
-            "戴冠战-不匹配关闭"
-        ]
-    },
     "冠位戴冠战-开始": {
         "focus": {
             "Node.Action.Starting": "<span style=\"color: #FF0000;\">开始戴冠战</span>"
@@ -218,7 +204,7 @@
                 ]
             }
         },
-        "repeat": 4,
+        "repeat": 5,
         "post_delay": 5000,
         "next": [
             "戴冠战-尝试进入副本"
@@ -285,5 +271,19 @@
         "focus": {
             "Node.Recognition.Starting": "未找到对应职介！脚本中止"
         }
+    },
+    "戴冠战-确定弹窗有打开": {
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "template": [
+                    "grand/grand_cancel.png"
+                ]
+            }
+        },
+        "next": [
+            "戴冠战-匹配检测",
+            "戴冠战-不匹配关闭"
+        ]
     }
 }

--- a/assets/tasks/更新settings.json
+++ b/assets/tasks/更新settings.json
@@ -3,7 +3,7 @@
     {
       "name": "更新bbc脚本",
       "label": "导入bbc队伍配置",
-      "description": "maa更新或有修改过bbc队伍配置后需要使用该功能。\n使用方式：仅勾选此任务，然后点击开始任务。\n<span style=\"color: #FF0000;\">无效时请直接在根目录双击restart_mfa.exe</span>\nMWU版本无需使用该功能,原生配置选择界面支持点击刷新更新下拉菜单. ",
+      "description": "仅限MXU版本（网页版本请勿使用）：\nmaa更新或有修改过bbc队伍配置后需要使用该功能。\n使用方式：仅勾选此任务，然后点击开始任务。\n<span style=\"color: #FF0000;\">无效时请直接在根目录双击restart_mfa.exe</span>\n ",
       "entry": "更新settings"
     }
   ]


### PR DESCRIPTION
[feat: 更新bbc脚本描述，明确仅限MXU版本使用](https://github.com/xlxyvergil/MaaFgo/commit/4f03d7460cd40373721daadad1e13e7a9af0510b)

[feat: 戴冠战最后一关逻辑优化，现在会正确跳过不能打的关](https://github.com/xlxyvergil/MaaFgo/commit/86a86a44644e6899004404f198dc7fc5e014267d)

## Summary by Sourcery

优化戴冠战 final-stage 处理，并在相关配置中明确 MXU 专用用法。

Bug Fixes（错误修复）:
- 确保在无法进行时，正确跳过最终戴冠战阶段。

Enhancements（增强）:
- 优化流水线和任务配置中的戴冠战 final-stage 逻辑。

Documentation（文档）:
- 更新 bbc 脚本说明，明确指出其仅适用于 MXU 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize戴冠战final-stage handling and clarify MXU-specific usage in related configurations.

Bug Fixes:
- Ensure the final戴冠战stage is correctly skipped when it cannot be played.

Enhancements:
- Refine pipeline and task configuration for戴冠战 final-stage logic.

Documentation:
- Update bbc script description to explicitly state it is only for the MXU version.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加弹窗确认步骤以完善进入副本的判定流程

* **优化**
  * 调整进入副本后的流程逻辑，优化判定顺序

* **文档**
  * 更新任务说明文案，明确版本适用范围

<!-- end of auto-generated comment: release notes by coderabbit.ai -->