### PR TITLE
fix: 注释掉不需要的 restart 文件复制步骤

### DIFF
--- a/assets/Announcement.md
+++ b/assets/Announcement.md
@@ -22,7 +22,7 @@
 
 ## 📖 更多帮助
 
-- 使用说明、功能列表、常见问题请参阅 [README.md](https://github.com/xlxyvergil/MaaFgo)
+- 使用说明、功能列表、常见问题请参阅 [使用说明](https://www.bilibili.com/opus/1205585422954004514?spm_id_from=333.1387.0.0)
 - 遇到 bug 请前往 [GitHub Issues](https://github.com/xlxyvergil/MaaFgo/issues) 或QQ群反馈
 
 ---

--- a/tools/install-MWU.py
+++ b/tools/install-MWU.py
@@ -200,7 +200,7 @@ if __name__ == "__main__":
     install_chores()
     install_bbcdll()  # 复制 bbcdll 目录
     install_tasks()  # 复制 tasks 目录
-    install_restart_files()  # 复制 restart 文件
+    # install_restart_files()  # MWU 版本不需要 restart_mfa.exe
     fix_cv2_path()  # 修复 cv2 模块路径
 
     print(f"Install to {install_path} successfully.")

--- a/tools/install-MWU.py
+++ b/tools/install-MWU.py
@@ -144,6 +144,10 @@ def install_chores():
         working_dir / "LICENSE",
         install_path,
     )
+    # 复制公告文件（MaaUI 欢迎页）
+    announcement = working_dir / "assets" / "Announcement.md"
+    if announcement.exists():
+        shutil.copy2(announcement, install_path)
 
 
 def install_bbcdll():

--- a/tools/install-MXU.py
+++ b/tools/install-MXU.py
@@ -123,6 +123,10 @@ def install_chores():
                 working_dir / file,
                 install_path,
             )
+    # 复制公告文件（MaaUI 欢迎页）
+    announcement = working_dir / "assets" / "Announcement.md"
+    if announcement.exists():
+        shutil.copy2(announcement, install_path)
 
 
 def install_agent():


### PR DESCRIPTION
[fix: 注释掉不需要的 restart 文件复制步骤](https://github.com/xlxyvergil/MaaFgo/commit/00b65cd22ec602928af5bd7319d6278e8a8a5935)

## Summary by Sourcery

更新 MWU/MXU 安装程序，以处理公告文件并移除不必要的重启文件复制。

新功能：
- 为 MWU 和 MXU 构建添加自动复制 Announcement.md 文件到安装目录的功能。

错误修复：
- 在 MWU 安装程序中禁用重启文件的复制，因为不需要 restart_mfa.exe。
- 更新公告文档中的帮助链接，使其指向外部使用指南，而不是 README。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update MWU/MXU installers to handle announcement files and remove unnecessary restart file copying.

New Features:
- Add automatic copying of the Announcement.md file into the install directory for MWU and MXU builds.

Bug Fixes:
- Disable copying of restart files in the MWU installer since restart_mfa.exe is not needed.
- Update the help link in the announcement document to point to an external usage guide instead of the README.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档更新**
  * 更新公告中的帮助文档链接

* **优化改进**
  * 安装程序现包含公告文件的安装逻辑
  * 调整安装流程配置

<!-- end of auto-generated comment: release notes by coderabbit.ai -->