### PR TITLE
fix: 更新通用大活动和通用小活动的默认副本类型为“上次挑战”

### DIFF
--- a/assets/options/通用大活动-副本类型.json
+++ b/assets/options/通用大活动-副本类型.json
@@ -2,7 +2,7 @@
   "option": {
     "通用大活动-副本类型": {
       "label": "$副本类型",
-      "default": "副本类型",
+      "default": "上次挑战",
       "type": "select",
       "description": "目前仅支持挑战上次的副本",
       "cases": [

--- a/assets/options/通用小活动-副本类型.json
+++ b/assets/options/通用小活动-副本类型.json
@@ -2,7 +2,7 @@
   "option": {
     "通用小活动-副本类型": {
       "label": "$副本类型",
-      "default": "副本类型",
+      "default": "上次挑战",
       "type": "select",
       "description": "无描述",
       "cases": [


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 将通用的大型和小型事件的默认副本类型与上一项挑战保持一致，以修复初始选择行为不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Align generic large and small event default copy type with the previous challenge to fix incorrect initial selection behavior.

</details>