### PR TITLE
fix:免责声明不处理

### DIFF
--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -519,9 +519,14 @@ class ExecuteBbcTask(CustomAction):
             popup_id = msg.get('popup_id', '')
             
             mfaalog.info(f"[Callback] 收到弹窗: {popup_title}")
-            
+
+            # 免责声明弹窗: 最高优先级, 无论何时出现都不视为战斗结束/bbc结束。
+            # BBC Server自动关闭, 只记录日志忽略, 不进入下方任何结束性分支。
+            if '免责声明' in popup_title or '免责声明' in popup_message:
+                mfaalog.info(f"[Callback] 免责声明弹窗(非战斗结束, BBC自动关闭), 忽略继续: {popup_title}:{popup_message}")
+                # 不设置 state['finished'], 战斗继续
             # 处理助战排序不符合 (askyesno 类型，使用布尔值 True/False)
-            if '助战排序不符合' in popup_title:
+            elif '助战排序不符合' in popup_title:
                 action = support_order_mismatch  # True=继续, False=停止
                 mfaalog.info(f"[Callback] 助战弹窗(askyesno)，响应: {action}")
                 


### PR DESCRIPTION
## Summary by Sourcery

Bug 修复：
- 将免责声明弹窗视为非终止事件，将其忽略，不再结束战斗或 BBC 运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Treat disclaimer popups as non-terminal events that are ignored and do not end battles or BBC runs.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化免责声明弹窗的处理逻辑，识别后将记录日志并继续流程，避免误触发结束操作。
  * 保留助战排序弹窗的正常处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->