### PR TITLE
feat: 添加BBC停止监听器，支持任意时间停止BBC任务

### DIFF
--- a/agent/custom/bbc_action.py
+++ b/agent/custom/bbc_action.py
@@ -198,7 +198,7 @@ class ExecuteBbcTask(CustomAction):
             
             # 步骤3: 配置并启动战斗（同时启动回调监听）
             battle_result = self._setup_and_start_battle(
-                team_config, run_count, apple_type, battle_type,
+                context, team_config, run_count, apple_type, battle_type,
                 support_order_mismatch, team_config_error, state, manager
             )
             if battle_result is None:
@@ -399,7 +399,7 @@ class ExecuteBbcTask(CustomAction):
             mfaalog.error("[ExecuteBbcTask] BBC重启失败")
             return False
     
-    def _setup_and_start_battle(self, team_config: str, run_count: int, 
+    def _setup_and_start_battle(self, context: Context, team_config: str, run_count: int, 
                                 apple_type: str, battle_type: BattleType,
                                 support_order_mismatch: bool, team_config_error: bool,
                                 state: dict, manager) -> dict:
@@ -453,6 +453,14 @@ class ExecuteBbcTask(CustomAction):
         battle_started = False
         
         for retry in range(max_retries):
+            # MXU 点停止后立即中断启动流程
+            if context.tasker.stopping:
+                mfaalog.info("[ExecuteBbcTask] 检测到任务停止信号，中断战斗启动")
+                state['finished'] = True
+                state['popup_title'] = '脚本停止'
+                state['popup_message'] = '任务已停止'
+                return state
+
             # 发送启动命令
             result = manager.send_command('start_battle', {}, timeout=10)
             if not result.get('success'):
@@ -622,6 +630,9 @@ class ExecuteBbcTask(CustomAction):
         3. 心跳成功后截图并运行"助战错误识别"pipeline，识别到助战错误则停止BBC脚本并正常结束任务
         4. 弹窗处理由回调函数在后台线程完成，通过 state['finished'] 通知主线程
         5. 当 state['finished'] 为 True 时，返回弹窗信息
+
+        停止响应：循环内以短间隔轮询 Tasker.stopping()，
+        MXU 点停止（post_stop）后立即感知并中断等待，避免任务停不下来。
         """
 
         # 获取 manager 实例
@@ -631,9 +642,22 @@ class ExecuteBbcTask(CustomAction):
         heartbeat_interval = 30  # 30秒一次心跳
         miss_count = 0           # 连续识别到助战错误的次数
         miss_threshold = 1       # 阈值，达到则停止BBC脚本并正常结束任务
+        last_heartbeat = time.time()
 
         while not state['finished']:
-            time.sleep(heartbeat_interval)
+            # 短间隔轮询停止信号：MXU post_stop 后 stopping() 立即为 True
+            if context.tasker.stopping:
+                mfaalog.info("[ExecuteBbcTask] 检测到任务停止信号，中断战斗等待")
+                state['finished'] = True
+                state['popup_title'] = '脚本停止'
+                state['popup_message'] = '任务已停止'
+                break
+
+            # 达到心跳间隔才执行心跳检查（避免高频截图/识别）
+            if time.time() - last_heartbeat < heartbeat_interval:
+                time.sleep(1)
+                continue
+            last_heartbeat = time.time()
 
             # 心跳检查：发送 get_status 命令验证 BBC 服务是否正常
             status = manager.send_command('get_status', {}, timeout=5)

--- a/agent/custom/bbc_connection_manager.py
+++ b/agent/custom/bbc_connection_manager.py
@@ -516,11 +516,20 @@ class BbcConnectionManager:
     
     # ==================== 完整重启流程 ====================
     
-    def restart_bbc_and_connect(self, connect_cmd: str, connect_args: dict, max_retries: int = 5) -> bool:
-        """重启 BBC 并连接模拟器（完整流程）"""
+    def restart_bbc_and_connect(self, connect_cmd: str, connect_args: dict, max_retries: int = 5, stop_check: Optional[callable] = None) -> bool:
+        """重启 BBC 并连接模拟器（完整流程）
+
+        stop_check: 可选回调，每次循环迭代前调用，返回 True 表示应停止（如 MXU 停止任务），
+        此时立即中止重启流程并返回 False。
+        """
         mfaalog.info(f"[BbcConnectionManager] ========== 开始重启 BBC ==========")
         
         for attempt in range(1, max_retries + 1):
+            # 停止检查：MXU post_stop 后立即中止，不再拉起 BBC
+            if stop_check is not None and stop_check():
+                mfaalog.info("[BbcConnectionManager] 检测到停止信号，中止 BBC 重启流程")
+                return False
+
             mfaalog.info(f"[BbcConnectionManager] 第{attempt}次启动尝试")
             
             # 清空本次尝试的消息队列和就绪事件

--- a/agent/custom/bbc_start.py
+++ b/agent/custom/bbc_start.py
@@ -117,11 +117,18 @@ class StartBbc(CustomAction):
             # 步骤2: Kill掉所有BBC进程（清理残留窗口）
             mfaalog.info("[StartBbc] 步骤2: 清理所有BBC进程...")
             self._kill_all_bbc_processes()
+            if context.tasker.stopping:
+                mfaalog.info("[StartBbc] 检测到任务停止信号，中止 BBC 启动")
+                return CustomAction.RunResult(success=False)
             time.sleep(2)
             
             # 步骤3: 调用Manager的完整重启流程
             mfaalog.info("[StartBbc] 步骤3: 调用Manager重启BBC并连接模拟器...")
-            success = manager.restart_bbc_and_connect(connect_cmd, connect_args, max_retries=5)
+            # 传入停止检查回调：MXU 点停止（post_stop）后立即中止，不再拉起 BBC
+            success = manager.restart_bbc_and_connect(
+                connect_cmd, connect_args, max_retries=5,
+                stop_check=lambda: context.tasker.stopping,
+            )
             
             if success:
                 mfaalog.info("[StartBbc] BBC启动并连接成功")

--- a/agent/custom/bbc_stop_listener.py
+++ b/agent/custom/bbc_stop_listener.py
@@ -1,0 +1,57 @@
+"""
+BBC 停止监听器 - 监听任务停止信号，自动关闭 BBC
+
+原理：
+MXU 停止任务时会对 Tasker 调用 post_stop()，Maa 框架会执行一个
+entry 为 "MaaTaskerPostStop" 的内部任务。该事件会通过 tasker sink
+转发到 agent 进程，此处据此判断"任务被停止"，然后强杀 BBC 进程。
+
+不依赖 MXU 的断开/kill agent 行为，agent 存活期间即可生效。
+"""
+import os
+import sys
+
+import psutil
+from maa.agent.agent_server import AgentServer
+from maa.tasker import TaskerEventSink
+
+import mfaalog
+
+# 确保 custom 目录在 sys.path 中
+_custom_dir = os.path.dirname(os.path.abspath(__file__))
+if _custom_dir not in sys.path:
+    sys.path.insert(0, _custom_dir)
+
+# MXU 停止任务时 post_stop() 触发的内部任务 entry 名
+STOP_ENTRY = "MaaTaskerPostStop"
+
+
+def _kill_bbc_processes() -> int:
+    """强杀所有 BBchannel 进程，返回被杀数量"""
+    killed = 0
+    for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
+        try:
+            name = (proc.info.get('name') or '').lower()
+            cmdline = proc.info.get('cmdline') or []
+            if 'bbchannel' in name or any('BBchannel' in arg for arg in cmdline):
+                mfaalog.info(f"[BbcStopListener] 强制杀死 BBC 进程 PID: {proc.pid}")
+                proc.kill()
+                killed += 1
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return killed
+
+
+@AgentServer.tasker_sink()
+class BbcStopOnTaskStop(TaskerEventSink):
+    """任务被停止时关闭 BBC"""
+
+    def on_tasker_task(self, tasker, noti_type, detail):
+        # MXU 停止任务 → post_stop → entry 为 MaaTaskerPostStop 的内部任务
+        if getattr(detail, 'entry', '') == STOP_ENTRY:
+            mfaalog.info("[BbcStopListener] 检测到任务停止信号，关闭 BBC...")
+            try:
+                killed = _kill_bbc_processes()
+                mfaalog.info(f"[BbcStopListener] 已关闭 {killed} 个 BBC 进程")
+            except Exception as e:
+                mfaalog.warning(f"[BbcStopListener] 关闭 BBC 失败: {e}")

--- a/agent/main.py
+++ b/agent/main.py
@@ -21,6 +21,7 @@ import mfaalog
 import bbc_action
 import bbc_start
 import bbc_stop
+import bbc_stop_listener
 import general_navigation_action
 
 


### PR DESCRIPTION
## Summary by Sourcery

为与 BBC 相关的工作流加入任务停止（task-stop）感知能力，以便在 MXU 任务被停止时，BBC 可以立即被中断并关闭。

Enhancements:
- 在战斗启动流程中传递 `Context`，并周期性检查 `tasker.stopping`，在任务被停止时中止战斗启动和等待循环。
- 为 BBC 的重启与连接流程扩展一个可选的停止检查回调，在检测到停止信号时取消重启尝试。
- 在 BBC 启动流程中添加提前停止处理逻辑：如果任务在杀掉现有 BBC 进程之后已被停止，则直接中止启动。
- 引入 BBC 停止监听器，响应 `MaaTaskerPostStop` 事件，在任务被停止时强制终止所有 `BBchannel` 进程。

Documentation:
- 更新内联文档/注释，说明 BBC 战斗等待逻辑中的新的停止处理行为和轮询策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add task-stop awareness to BBC-related workflows so BBC can be interrupted and shut down immediately when the MXU task is stopped.

Enhancements:
- Propagate Context into battle startup and periodically check tasker.stopping to abort battle startup and waiting loops when the task is stopped.
- Extend BBC restart-and-connect flow with an optional stop-check callback to cancel restart attempts when a stop signal is detected.
- Add early-stop handling in BBC startup to abort after killing existing BBC processes if the task has been stopped.
- Introduce a BBC stop listener that reacts to MaaTaskerPostStop events and forcefully terminates all BBchannel processes when the task is stopped.

Documentation:
- Update inline documentation/comments to describe new stop handling behavior and polling strategy in BBC battle wait logic.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增任务停止监听机制，停止任务后会自动终止相关后台进程。
  * 启动和重连流程支持及时响应停止信号，避免继续执行后续操作。

* **问题修复**
  * 优化战斗等待与启动过程，能够更快识别任务已停止状态。
  * 修复停止任务后仍可能继续启动或重试连接的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->