### PR TITLE
fix: 助战YOLO检测框坐标取整, 修复 TypeError

### DIFF
--- a/agent/custom/support_action.py
+++ b/agent/custom/support_action.py
@@ -199,7 +199,9 @@ class SupportDetector:
             boxes = self.model.detect(img, conf=LOW_CONF)
         # 按 y 排序(条目顺序)
         boxes.sort(key=lambda b: (b[1], b[0]))
-        return [(x1, y1, x2, y2, c) for (x1, y1, x2, y2, c, _cl) in boxes]
+        # 坐标统一取整: YOLO/ONNX 输出的框坐标可能是 float, 直接用于切片会触发
+        # "TypeError: slice indices must be integers"
+        return [(int(x1), int(y1), int(x2), int(y2), c) for (x1, y1, x2, y2, c, _cl) in boxes]
 
 
 # ---------------- 助战 Action ----------------
@@ -248,6 +250,7 @@ class SupportAction(CustomAction):
         # 头像匹配: 裁剪框内头像区域, 用多边形 mask 物理排除覆盖 UI(金星/职介/等级/星级),
         # 再把多边形外像素设为脸部均值(中性化, 不参与相关度), 最后在 servant_face 模板上滑动匹配
         import cv2
+        bx, by = int(bx), int(by)
         fxs = [p[0] for p in FACE_POLY]; fys = [p[1] for p in FACE_POLY]
         xmin, xmax, ymin, ymax = min(fxs), max(fxs), min(fys), max(fys)
         poly = img[by + ymin:by + ymax + 1, bx + xmin:bx + xmax + 1]
@@ -272,6 +275,7 @@ class SupportAction(CustomAction):
     # ---------- 礼装匹配 ----------
     def _match_ce(self, img, ce_dir, bx, by, ce_name, anchor, ce_sub=""):
         import cv2
+        bx, by = int(bx), int(by)
         if ce_name in EMPTY_CE:
             mfaalog.info("[SupportAction] 礼装为空(跳过匹配)")
             return True


### PR DESCRIPTION
## 修复内容

### 助战 Action YOLO 框坐标取整 (TypeError 修复)
- \SupportDetector.detect()\ 将 ONNX 输出的 float 框坐标统一 \int()\ 取整
- \_match_servant\ / \_match_ce\ 入口增加防御性取整
- 修复部分用户运行时报错: \TypeError: slice indices must be integers or None or have an index method\ (报错位置 \support_action.py\ \_match_servant\ 的 \img[by+ymin:...]\ 切片)

已 rebase 到最新 main (#182 ONNX 迁移之后), 无冲突。

## Sourcery 总结

修复助战坐标处理问题，并扩展战斗流程调度，以支持进入地下城和体力耗尽的情况。

Bug 修复：
- 在进行图像切片前，将 YOLO 检测坐标和匹配坐标规范化为整数，避免助战卡图像匹配失败。

功能增强：
- 通过添加进入地下城步骤，并在体力不足时重置节点列表，改进原生自动战斗和连续部署流程的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix assist coordinate handling and extend battle-flow scheduling for dungeon entry and stamina exhaustion.

Bug Fixes:
- Prevent assist-card image matching failures by normalizing YOLO detection and matching coordinates to integers before image slicing.

Enhancements:
- Improve native auto-battle and consecutive-deployment flow handling by adding the dungeon-entry step and resetting node lists when stamina is insufficient.

</details>